### PR TITLE
Add width styles to text component

### DIFF
--- a/frontend/nginx/client.conf
+++ b/frontend/nginx/client.conf
@@ -1,7 +1,10 @@
+limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
+
 server {
     listen       80;
 
     location / {
+        limit_req zone=mylimit burst=20 nodelay;
         root /usr/share/nginx/html;
         index index.html index.htm;
         try_files $uri $uri/ /index.html =404;

--- a/frontend/src/Components/Notes/Notes.jsx
+++ b/frontend/src/Components/Notes/Notes.jsx
@@ -39,10 +39,17 @@ const Notes = () => {
   return (
     <Box>
       <Box className={classes.rowContainer}>
-        <TextComponent value={'Rough Notes'} gutterBottom={true} loading={false} textStyle={classes.text} />
+        <TextComponent
+          value={'Rough Notes'}
+          gutterBottom={true}
+          loading={false}
+          textStyle={classes.text}
+          fullWidth={true}
+        />
         <Box className={classes.emptyGap}></Box>
         <ButtonComponent
           buttonVariant={'text'}
+          disabled={true}
           icon={<ImportExportRounded />}
           showIcon={true}
           text={'Sort'}

--- a/frontend/src/Components/Notes/NotesDetails.jsx
+++ b/frontend/src/Components/Notes/NotesDetails.jsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(2),
+    width: '100vw', // set width to force inside content to be 100%
   },
   rowContainer: {
     display: 'flex',
@@ -159,6 +160,7 @@ const NotesDetails = () => {
                     <TextComponent
                       value={note.note_title}
                       gutterBottom={true}
+                      fullWidth={true}
                       loading={loading}
                       textStyle={[classes.text, classes.textVariant].join(' ')}
                     />

--- a/frontend/src/stories/TextComponent/TextComponent.jsx
+++ b/frontend/src/stories/TextComponent/TextComponent.jsx
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import { Typography } from '@material-ui/core';
 import LoadingSkeleton from '../../util/LoadingSkeleton';
 
-const TextComponent = ({ textStyle, loading, gutterBottom, value }) => {
+const TextComponent = ({ fullWidth, textStyle, loading, gutterBottom, value }) => {
   if (loading) {
     return <LoadingSkeleton width={`calc(100% - 1rem)`} height={'2rem'} />;
   }
   return (
-    <Typography className={textStyle} gutterBottom={gutterBottom}>
+    <Typography fullWidth={fullWidth} className={textStyle} gutterBottom={gutterBottom}>
       {value}
     </Typography>
   );
@@ -16,6 +16,7 @@ const TextComponent = ({ textStyle, loading, gutterBottom, value }) => {
 TextComponent.defaultProps = {
   textStyle: '',
   loading: true,
+  fullWidth: true,
   gutterBottom: true,
   value: 'John Doe',
 };
@@ -24,6 +25,7 @@ TextComponent.propTypes = {
   textStyle: PropTypes.string,
   gutterBottom: PropTypes.bool,
   loading: PropTypes.bool,
+  fullWidth: PropTypes.bool,
   value: PropTypes.string,
 };
 


### PR DESCRIPTION
- add width styles to text component
- add full width to notes compoenent so that all notes would have full width as a property. they strech the full size of the screen regardless of text size.
- add disable property to sorting for notes atm

closes #85 #86