### PR TITLE
add inventories for user

### DIFF
--- a/apilayer/dataLake/hoard/dataLake.go
+++ b/apilayer/dataLake/hoard/dataLake.go
@@ -300,7 +300,7 @@ func populateFakePersonalInventories(user string, limit int, creatorID string) {
 		draftInventory.UpdaterName = gofakeit.FirstName()
 		draftInventory.BoughtAt = gofakeit.CarMaker()
 
-		db.AddInventory(user, draftInventory, creatorID)
+		db.AddInventory(user, creatorID, draftInventory)
 	}
 }
 

--- a/apilayer/dataLake/hoard/dataLake.go
+++ b/apilayer/dataLake/hoard/dataLake.go
@@ -285,8 +285,8 @@ func populateFakePersonalInventories(user string, limit int, creatorID string) {
 
 		draftInventory.Name = gofakeit.HipsterWord()
 		draftInventory.Description = gofakeit.HipsterSentence(2)
-		draftInventory.Price = fmt.Sprintf("%s", gofakeit.Price(2, 120))
-		draftInventory.Status = gofakeit.BuzzWord()
+		draftInventory.Price = fmt.Sprintf("%f", gofakeit.Price(2, 120))
+		draftInventory.Status = gofakeit.RandString([]string{"COUPONS", "DRAFT", "HIDDEN"})
 		draftInventory.Barcode = gofakeit.Date().String()
 		draftInventory.SKU = gofakeit.Date().String()
 		draftInventory.Quantity = gofakeit.Number(10, 100)
@@ -300,7 +300,7 @@ func populateFakePersonalInventories(user string, limit int, creatorID string) {
 		draftInventory.UpdaterName = gofakeit.FirstName()
 		draftInventory.BoughtAt = gofakeit.CarMaker()
 
-		db.AddInventory(user, creatorID, draftInventory)
+		db.AddInventory(user, draftInventory, creatorID)
 	}
 }
 

--- a/apilayer/dataLake/hoard/dataLake.go
+++ b/apilayer/dataLake/hoard/dataLake.go
@@ -47,6 +47,7 @@ func IngestSvc() {
 	GenerateFakeDataWithLimit(currentUser, 20, "expense", creatorID)
 	GenerateFakeDataWithLimit(currentUser, 20, "item", creatorID)
 	GenerateFakeDataWithLimit(currentUser, 20, "note", creatorID)
+	GenerateFakeDataWithLimit(currentUser, 20, "inventory", creatorID)
 
 }
 
@@ -79,6 +80,9 @@ func GenerateFakeDataWithLimit(user string, minCount int, typeOf string, creator
 	case "note":
 		log.Printf("loading %d of note rows", rowCounts)
 		populateFakePersonalNotes(user, rowCounts, creatorID)
+	case "inventory":
+		log.Printf("loading %d of inventory rows", rowCounts)
+		populateFakePersonalInventories(user, rowCounts, creatorID)
 	default:
 	}
 	return nil
@@ -263,6 +267,40 @@ func populateFakePersonalNotes(user string, limit int, creatorID string) {
 		draftNote.Updator = gofakeit.FirstName()
 
 		db.AddNewNote(user, creatorID, draftNote)
+	}
+}
+
+// populateFakePersonalInventories ...
+//
+// generate fake personal inventories data to test in the application
+func populateFakePersonalInventories(user string, limit int, creatorID string) {
+
+	for i := 1; i <= limit; i++ {
+		draftInventory := model.Inventory{}
+
+		// time is set for created / updated
+		now := time.Now()
+		daysAgo := gofakeit.Number(1, 30)
+		startDate := now.AddDate(0, 0, -daysAgo)
+
+		draftInventory.Name = gofakeit.HipsterWord()
+		draftInventory.Description = gofakeit.HipsterSentence(2)
+		draftInventory.Price = fmt.Sprintf("%s", gofakeit.Price(2, 120))
+		draftInventory.Status = gofakeit.BuzzWord()
+		draftInventory.Barcode = gofakeit.Date().String()
+		draftInventory.SKU = gofakeit.Date().String()
+		draftInventory.Quantity = gofakeit.Number(10, 100)
+		draftInventory.Location = gofakeit.BuzzWord()
+		draftInventory.IsResolved = gofakeit.Bool()
+		draftInventory.CreatedAt = startDate
+		draftInventory.UpdatedAt = startDate
+		draftInventory.CreatedBy = creatorID
+		draftInventory.CreatorName = gofakeit.FirstName()
+		draftInventory.UpdatedBy = creatorID
+		draftInventory.UpdaterName = gofakeit.FirstName()
+		draftInventory.BoughtAt = gofakeit.CarMaker()
+
+		db.AddInventory(user, creatorID, draftInventory)
 	}
 }
 

--- a/apilayer/db/Inventorydb.go
+++ b/apilayer/db/Inventorydb.go
@@ -1,6 +1,11 @@
 package db
 
-import "github.com/mohit2530/communityCare/model"
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mohit2530/communityCare/model"
+)
 
 // RetrieveAllInventoriesForUser ...
 func RetrieveAllInventoriesForUser(user string, userID string) ([]model.Inventory, error) {
@@ -82,4 +87,75 @@ ORDER BY
 		return make([]model.Inventory, 0), nil
 	}
 	return data, nil
+}
+
+// AddInventory ...
+func AddInventory(user string, draftInventory model.Inventory, userID string) (*model.Inventory, error) {
+
+	db, err := SetupDB(user)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	sqlStr := `INSERT INTO community.inventory
+	(name, description, price, status, barcode, sku, quantity, boughtAt, location, storage_location_id, created_by, created_at, updated_by, updated_at)
+    VALUES
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	RETURNING id`
+
+	// storage location is unique key in the database.
+	// storage location can be shared across inventories and items that are stored in events.
+	parsedStorageLocationID, err := uuid.Parse(draftInventory.Location)
+	if err != nil {
+		// if the location is not a uuid type, then it should resemble a new storage location
+		emptyLocationID := ""
+		err := addNewStorageLocation(user, draftInventory.Location, draftInventory.CreatedBy, &emptyLocationID)
+		if err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+		parsedStorageLocationID, err = uuid.Parse(emptyLocationID)
+		if err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+		draftInventory.StorageLocationID = emptyLocationID
+	}
+
+	err = tx.QueryRow(
+		sqlStr,
+		draftInventory.Name,
+		draftInventory.Description,
+		draftInventory.Price,
+		draftInventory.Status,
+		draftInventory.Barcode,
+		draftInventory.SKU,
+		draftInventory.Quantity,
+		draftInventory.BoughtAt,
+		draftInventory.Location,
+		parsedStorageLocationID,
+		draftInventory.CreatedBy,
+		time.Now(),
+		draftInventory.UpdatedBy,
+		time.Now(),
+	).Scan(&draftInventory.ID)
+
+	if err != nil {
+		// Rollback the transaction if there is an error
+		tx.Rollback()
+		return nil, err
+	}
+
+	// Commit the transaction if everything is successful
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &draftInventory, nil
 }

--- a/apilayer/db/Inventorydb.go
+++ b/apilayer/db/Inventorydb.go
@@ -90,7 +90,7 @@ ORDER BY
 }
 
 // AddInventory ...
-func AddInventory(user string, draftInventory model.Inventory, userID string) (*model.Inventory, error) {
+func AddInventory(user string, userID string, draftInventory model.Inventory) (*model.Inventory, error) {
 
 	db, err := SetupDB(user)
 	if err != nil {
@@ -102,12 +102,6 @@ func AddInventory(user string, draftInventory model.Inventory, userID string) (*
 	if err != nil {
 		return nil, err
 	}
-
-	sqlStr := `INSERT INTO community.inventory
-	(name, description, price, status, barcode, sku, quantity, boughtAt, location, storage_location_id, created_by, created_at, updated_by, updated_at)
-    VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-	RETURNING id`
 
 	// storage location is unique key in the database.
 	// storage location can be shared across inventories and items that are stored in events.
@@ -127,6 +121,12 @@ func AddInventory(user string, draftInventory model.Inventory, userID string) (*
 		}
 		draftInventory.StorageLocationID = emptyLocationID
 	}
+
+	sqlStr := `INSERT INTO community.inventory
+	(name, description, price, status, barcode, sku, quantity, boughtAt, location, storage_location_id, created_by, created_at, updated_by, updated_at)
+    VALUES
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	RETURNING id`
 
 	err = tx.QueryRow(
 		sqlStr,
@@ -152,7 +152,6 @@ func AddInventory(user string, draftInventory model.Inventory, userID string) (*
 		return nil, err
 	}
 
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}

--- a/apilayer/db/Inventorydb.go
+++ b/apilayer/db/Inventorydb.go
@@ -31,7 +31,6 @@ func RetrieveAllInventoriesForUser(user string, userID string) ([]model.Inventor
     inv.updated_at
 FROM
     community.inventory inv
-LEFT JOIN community.projects p ON inv.project_id = p.id
 LEFT JOIN community.profiles cp ON inv.created_by = cp.id
 LEFT JOIN community.profiles up ON inv.updated_by = up.id
 WHERE

--- a/apilayer/db/Notedb.go
+++ b/apilayer/db/Notedb.go
@@ -70,7 +70,6 @@ func AddNewNote(user string, userID string, draftNote model.Note) (*model.Note, 
 		return nil, err
 	}
 
-	// for add scenarios
 	var draftNoteID string
 	draftNote.CreatedAt = time.Now()
 	draftNote.UpdatedAt = time.Now()
@@ -94,12 +93,10 @@ func AddNewNote(user string, userID string, draftNote model.Note) (*model.Note, 
 	).Scan(&draftNoteID)
 
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
 
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -150,11 +147,9 @@ func UpdateSelectedNote(user string, userID string, draftNote model.Note) (*mode
 	)
 
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}

--- a/apilayer/db/Notificationsdb.go
+++ b/apilayer/db/Notificationsdb.go
@@ -72,7 +72,6 @@ LIMIT 10;
 	}
 
 	if len(data) == 0 {
-		// empty array to factor in for null
 		return make([]model.Notification, 0), nil
 	}
 	return data, nil
@@ -101,7 +100,6 @@ func UpdateSelectedNotification(user string, userID string, draftNotification mo
 
 	var updatedNotification model.Notification
 
-	// Use QueryRow instead of Exec to get the updated row
 	row := tx.QueryRow(sqlStr,
 		draftNotification.ID,
 		draftNotification.IsViewed,
@@ -123,12 +121,10 @@ func UpdateSelectedNotification(user string, userID string, draftNotification mo
 	)
 
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
 
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}

--- a/apilayer/db/Profiledb.go
+++ b/apilayer/db/Profiledb.go
@@ -99,7 +99,6 @@ func UpdateUserProfile(user string, userID string, draftProfile model.Profile) (
 
 	var updatedProfile model.Profile
 
-	// Use QueryRow instead of Exec to get the updated row
 	row := tx.QueryRow(sqlStr,
 		userID,
 		draftProfile.Username,
@@ -123,12 +122,10 @@ func UpdateUserProfile(user string, userID string, draftProfile model.Profile) (
 	)
 
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
 
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -159,7 +156,6 @@ func UpdateProfileAvatar(user string, userID string, header *multipart.FileHeade
 		RETURNING id, username, full_name, avatar_url, phone_number, goal, about_me, onlinestatus, role
 	`
 
-	// Use QueryRow instead of Exec to get the updated row
 	var avatarUrl sql.NullString // Assuming avatar_url is a string column, not bytea
 	var goal sql.NullString
 
@@ -169,7 +165,7 @@ func UpdateProfileAvatar(user string, userID string, header *multipart.FileHeade
 		&updatedProfile.ID,
 		&updatedProfile.Username,
 		&updatedProfile.FullName,
-		&avatarUrl, // Use & for nullable columns
+		&avatarUrl,
 		&updatedProfile.PhoneNumber,
 		&goal,
 		&updatedProfile.AboutMe,
@@ -182,7 +178,6 @@ func UpdateProfileAvatar(user string, userID string, header *multipart.FileHeade
 		return nil, err
 	}
 
-	// Handle null values safely
 	if avatarUrl.Valid {
 		updatedProfile.AvatarUrl = avatarUrl.String
 	} else {
@@ -203,8 +198,6 @@ func UpdateProfileAvatar(user string, userID string, header *multipart.FileHeade
 }
 
 // RetrieveRecentActivity ...
-//
-// retrieves recent activities for a given user.
 func RetrieveRecentActivity(user string, userID uuid.UUID) ([]model.RecentActivity, error) {
 	db, err := SetupDB(user)
 	if err != nil {

--- a/apilayer/db/Userdb.go
+++ b/apilayer/db/Userdb.go
@@ -50,19 +50,15 @@ func SaveUser(user string, draftUser *model.UserCredentials) (*model.UserCredent
 	).Scan(&draftUserID)
 
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
 
-	// the draftUserID is generated from server.
 	draftUser.ID, err = uuid.Parse(draftUserID)
 	if err != nil {
-		// Rollback the transaction if there is an error
 		tx.Rollback()
 		return nil, err
 	}
-	// Commit the transaction if everything is successful
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -88,7 +84,6 @@ func RetrieveUser(user string, draftUser *model.UserCredentials) (*model.UserCre
 		return nil, err
 	}
 
-	// compare the stored encrpyted password vs the provided encrpyted password
 	if err = bcrypt.CompareHashAndPassword([]byte(storedCredentials.EncryptedPassword), []byte(draftUser.EncryptedPassword)); err != nil {
 		return nil, err
 	}
@@ -105,8 +100,6 @@ func RetrieveUser(user string, draftUser *model.UserCredentials) (*model.UserCre
 }
 
 // RemoveUser ...
-//
-// Restricted usage. elevated permissions are required
 func RemoveUser(user string, id uuid.UUID) error {
 	db, err := SetupDB(user)
 	if err != nil {

--- a/apilayer/go.mod
+++ b/apilayer/go.mod
@@ -2,8 +2,6 @@ module github.com/mohit2530/communityCare
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9

--- a/apilayer/handler/InventoriesHandler.go
+++ b/apilayer/handler/InventoriesHandler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/mohit2530/communityCare/db"
+	"github.com/mohit2530/communityCare/model"
 )
 
 // GetAllInventories ...
@@ -38,6 +39,58 @@ func GetAllInventories(rw http.ResponseWriter, r *http.Request, user string) {
 		json.NewEncoder(rw).Encode(err)
 		return
 	}
+	rw.Header().Add("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	json.NewEncoder(rw).Encode(resp)
+}
+
+// AddNewInventory ...
+// swagger:route POST /api/profile/{id}/inventories AddNewInventory addNewInventory
+//
+// # Add new personal item to the user inventory
+//
+// Parameters:
+//   - +name: id
+//     in: path
+//     description: The id of the selected note
+//     type: string
+//     required: true
+//   - +name: Inventory
+//     in: query
+//     description: The inventory object to add into the db
+//     type: object
+//     required: true
+//
+// Responses:
+// 200: MessageResponse
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func AddNewInventory(rw http.ResponseWriter, r *http.Request, user string) {
+	vars := mux.Vars(r)
+	userID := vars["id"]
+
+	if len(userID) <= 0 {
+		log.Printf("Unable to add new item with empty id")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	var inventory model.Inventory
+	if err := json.NewDecoder(r.Body).Decode(&inventory); err != nil {
+		log.Printf("Error decoding data. error: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	resp, err := db.AddInventory(user, userID, inventory)
+	if err != nil {
+		log.Printf("Unable to add new item. error: +%v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	rw.Header().Add("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusOK)
 	json.NewEncoder(rw).Encode(resp)

--- a/apilayer/handler/NotesHandler.go
+++ b/apilayer/handler/NotesHandler.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetUserNotesDetails ...
-// swagger:route GET /api/profile/notes/{id} GetUserNotesDetails getUserNotesDetails
+// swagger:route GET /api/profile/{id}/notes GetUserNotesDetails getUserNotesDetails
 //
 // # Retrieves the list of notes for the user.
 //
@@ -59,7 +59,7 @@ func GetUserNotesDetails(rw http.ResponseWriter, r *http.Request, user string) {
 }
 
 // AddNewNote ...
-// swagger:route POST /api/profile/notes/{id} AddNewNote addNewNote
+// swagger:route POST /api/profile/{id}/notes AddNewNote addNewNote
 //
 // # Add a new note to the database
 //
@@ -111,7 +111,7 @@ func AddNewNote(rw http.ResponseWriter, r *http.Request, user string) {
 }
 
 // UpdateNote ...
-// swagger:route PUT /api/profile/notes/{id} UpdateNote updateNote
+// swagger:route PUT /api/profile/{id}/notes UpdateNote updateNote
 //
 // # Updates an existing note in the database
 //
@@ -163,7 +163,7 @@ func UpdateNote(rw http.ResponseWriter, r *http.Request, user string) {
 }
 
 // RemoveSelectedNote ...
-// swagger:route DELETE /api/profile/notes/{id} RemoveSelectedNote removeSelectedNote
+// swagger:route DELETE /api/profile/{id}/notes RemoveSelectedNote removeSelectedNote
 //
 // # Removes the note from the db
 //

--- a/apilayer/main.go
+++ b/apilayer/main.go
@@ -88,12 +88,16 @@ func main() {
 	router.Handle("/api/v1/profile/{id}/updateAvatar", CustomRequestHandler(handler.UpdateProfileAvatar)).Methods(http.MethodPost)
 
 	router.Handle("/api/v1/profile/{id}/notifications", CustomRequestHandler(handler.GetAllNotifications)).Methods(http.MethodGet)
-	router.Handle("/api/v1/profile/{id}/inventories", CustomRequestHandler(handler.GetAllInventories)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}/notifications/{notificationID}", CustomRequestHandler(handler.UpdateSingleNotification)).Methods(http.MethodPut)
 
 	router.Handle("/api/v1/profile/{id}/recent", CustomRequestHandler(handler.GetUserRecentActivities)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}/highlights", CustomRequestHandler(handler.GetUserRecentHighlights)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}/volunteering", CustomRequestHandler(handler.GetUserVolunteerDetails)).Methods(http.MethodGet)
+
+	router.Handle("/api/v1/profile/{id}/inventories", CustomRequestHandler(handler.GetAllInventories)).Methods(http.MethodGet)
+	router.Handle("/api/v1/profile/{id}/inventories", CustomRequestHandler(handler.AddNewInventory)).Methods(http.MethodPost)
+	router.Handle("/api/v1/profile/{id}/inventories", CustomRequestHandler(handler.UpdateNote)).Methods(http.MethodPut)
+	router.Handle("/api/v1/profile/{id}/inventories", CustomRequestHandler(handler.RemoveSelectedNote)).Methods(http.MethodDelete)
 
 	router.Handle("/api/v1/profile/{id}/notes", CustomRequestHandler(handler.GetUserNotesDetails)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}/notes", CustomRequestHandler(handler.AddNewNote)).Methods(http.MethodPost)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "env-cmd": "^10.1.0",
     "immer": "^10.0.3",
     "lodash": "^4.17.21",
+    "mui-datatables": "^3.8.0",
     "notistack": "^3.0.1",
     "ol": "^8.1.0",
     "react": "^18.2.0",

--- a/frontend/src/Components/DrawerListComponent/List.jsx
+++ b/frontend/src/Components/DrawerListComponent/List.jsx
@@ -32,11 +32,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const List = ({ title, subtitle, data, columns, tooltipTitle, fileName, sheetName }) => {
+const List = ({ title, subtitle, data, columns, tableTitle, tableOptions }) => {
   const classes = useStyles();
-  const options = {
-    filterType: 'checkbox',
-  };
+
   return (
     <>
       <Typography className={classes.headerText}>{title}</Typography>
@@ -44,7 +42,7 @@ const List = ({ title, subtitle, data, columns, tooltipTitle, fileName, sheetNam
         <Box className={classes.rowContainer}>
           <Typography className={classes.text}>{subtitle}</Typography>
         </Box>
-        <MUIDataTable title={title} data={data} columns={columns} options={options} />
+        <MUIDataTable title={tableTitle} data={data} columns={columns} options={tableOptions} />
       </Box>
     </>
   );
@@ -54,26 +52,17 @@ List.defaultProps = {
   title: '',
   subtitle: '',
   data: [],
-  filteredData: [],
   columns: [],
-  columnHeaderFormatter: () => {},
   rowFormatter: () => {},
-  tooltipTitle: '',
-  fileName: '',
-  sheetName: '',
 };
 
 List.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   data: PropTypes.array,
-  filteredData: PropTypes.array,
   columns: PropTypes.array,
-  columnHeaderFormatter: PropTypes.func,
   rowFormatter: PropTypes.func,
-  tooltipTitle: PropTypes.string,
-  fileName: PropTypes.string,
-  sheetName: PropTypes.string,
+  tableTitle: PropTypes.string,
 };
 
 export default List;

--- a/frontend/src/Components/DrawerListComponent/List.jsx
+++ b/frontend/src/Components/DrawerListComponent/List.jsx
@@ -1,23 +1,13 @@
 import PropTypes from 'prop-types';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Typography,
-  Box,
-} from '@material-ui/core';
-
+import MUIDataTable from 'mui-datatables';
+import { Typography, Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import DownloadExcelButton from '../ItemDetail/DownloadExcelButton';
 
 const useStyles = makeStyles((theme) => ({
   container: {
     padding: theme.spacing(1),
-    maxHeight: '40vh',
+    height: `calc(100vh - 20rem)`,
+    overflow: 'auto',
   },
   tableHeaderCell: {
     fontWeight: 'bold',
@@ -42,51 +32,19 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const List = ({
-  title,
-  subtitle,
-  data,
-  filteredData,
-  columns,
-  columnHeaderFormatter,
-  rowFormatter,
-  tooltipTitle,
-  fileName,
-  sheetName,
-}) => {
+const List = ({ title, subtitle, data, columns, tooltipTitle, fileName, sheetName }) => {
   const classes = useStyles();
+  const options = {
+    filterType: 'checkbox',
+  };
   return (
     <>
       <Typography className={classes.headerText}>{title}</Typography>
       <Box className={classes.container}>
         <Box className={classes.rowContainer}>
           <Typography className={classes.text}>{subtitle}</Typography>
-          {data.length > 0 && (
-            <DownloadExcelButton data={data} tooltipTitle={tooltipTitle} fileName={fileName} sheetName={sheetName} />
-          )}
         </Box>
-        <TableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                {columns.map((column) => (
-                  <TableCell key={column} className={classes.tableHeaderCell}>
-                    {columnHeaderFormatter(column)}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {filteredData.map((row, rowIndex) => (
-                <TableRow key={rowIndex}>
-                  {columns.map((column) => (
-                    <TableCell key={column}>{rowFormatter(row, column, rowIndex)}</TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <MUIDataTable title={title} data={data} columns={columns} options={options} />
       </Box>
     </>
   );

--- a/frontend/src/Components/Event/EventDetailsCard.jsx
+++ b/frontend/src/Components/Event/EventDetailsCard.jsx
@@ -18,7 +18,6 @@ import { useDispatch } from 'react-redux';
 import EventProfile from './EventProfile';
 import { enqueueSnackbar } from 'notistack';
 import Title from '../DialogComponent/Title';
-import { isEditingAllowed } from './constants';
 import Drawer from '../DrawerListComponent/Drawer';
 import AddItemDetail from '../ItemDetail/AddItemDetail';
 import LoadingSkeleton from '../../util/LoadingSkeleton';
@@ -27,6 +26,7 @@ import { homeActions } from '../../Containers/Home/homeSlice';
 import { eventActions } from '../../Containers/Event/eventSlice';
 import EditCommunityEvent from '../CommunityEvent/EditCommunityEvent';
 import ReportCommunityEvent from '../CommunityEvent/ReportCommunityEvent';
+import { ADD_ITEMS_EVENT_FORM, ADD_NEW_EVENT_ITEM_SUBTITLE_TEXT, isEditingAllowed } from './constants';
 import { LowPriorityRounded, BugReportRounded, EditRounded, DoneRounded, PlaceRounded } from '@material-ui/icons';
 
 const useStyles = makeStyles((theme) => ({

--- a/frontend/src/Components/Event/constants.jsx
+++ b/frontend/src/Components/Event/constants.jsx
@@ -6,6 +6,9 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(relativeTime);
 
+export const ADD_NEW_EVENT_ITEM_SUBTITLE_TEXT =
+  'Add item that are required for this event. These items can be shared with other members of the group. Such shared items are stored with due process until the group is abandoned or until the creator removes the ability to share the items with other members.';
+
 export const EXISTING_PROJECTS_MSG =
   'By deactivating the project, all associated content and features will be disabled. This action cannot be undone.';
 
@@ -89,6 +92,77 @@ export const LABELS = [
     modifier: (value) => value || 'N/A',
   },
 ];
+
+const GENERIC_FORM_FIELDS = {
+  type: 'text',
+  variant: 'standard',
+};
+
+/**
+ * ADD ITEM EVENT FORM.
+ *
+ * Used to add new item in events personal profile.
+ */
+export const ADD_ITEMS_EVENT_FORM = {
+  name: {
+    label: 'Item Name',
+    placeholder: 'Enter product name',
+    value: '',
+    name: 'name',
+    errorMsg: '',
+    required: true,
+    fullWidth: true,
+    validators: [
+      {
+        validate: (value) => value.trim().length === 0,
+        message: 'Name is required',
+      },
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'Name should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS,
+  },
+  description: {
+    label: 'Item description',
+    placeholder: '',
+    value: '',
+    name: 'description',
+    errorMsg: '',
+    required: false,
+    fullWidth: true,
+    validators: [
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'Description should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS,
+  },
+  quantity: {
+    label: 'Quantity',
+    placeholder: '',
+    value: '',
+    name: 'quantity',
+    errorMsg: '',
+    required: true,
+    fullWidth: false,
+    validators: [
+      {
+        validate: (value) => value.trim().length === 0,
+        message: 'Quantity for the selected item is required',
+      },
+      {
+        validate: (value) =>
+          // test for number first, then
+          !(/^\d+$/.test(value) && parseInt(value) > 0),
+        message: 'A positive number is required',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS,
+  },
+};
 
 /**
  * Navigation tabs for EventDetailsDrawerComponent

--- a/frontend/src/Components/Inventory/Inventories.jsx
+++ b/frontend/src/Components/Inventory/Inventories.jsx
@@ -1,5 +1,5 @@
 import { Box, Container, Dialog, Tab, Tabs, Tooltip, makeStyles } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import TextComponent from '../../stories/TextComponent/TextComponent';
 import { AddRounded, CancelRounded, DoneRounded } from '@material-ui/icons';
 import ButtonComponent from '../../stories/Button/ButtonComponent';
@@ -9,8 +9,9 @@ import Title from '../DialogComponent/Title';
 import AddItemDetail from '../ItemDetail/AddItemDetail';
 import List from '../DrawerListComponent/List';
 import dayjs from 'dayjs';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { eventActions } from '../../Containers/Event/eventSlice';
+import { profileActions } from '../../Containers/Profile/profileSlice';
 
 const useStyles = makeStyles((theme) => ({
   rowContainer: {
@@ -39,6 +40,8 @@ const Inventories = () => {
   const dispatch = useDispatch();
   const [value, setValue] = useState(0);
   const [editMode, setEditMode] = useState(false);
+
+  const { loading: inventoriesLoading, inventories } = useSelector((state) => state.profile);
 
   const handleEditMode = () => {
     setEditMode(!editMode);
@@ -88,6 +91,7 @@ const Inventories = () => {
       bought_at: 'Walmart',
     },
   ];
+
   const columns = Object.keys(data.length > 0 && data[0]); // for header purpose
   // removing unwanted values from the display column
   const filteredItems = data?.map((item) => {
@@ -194,6 +198,10 @@ const Inventories = () => {
         return null;
     }
   };
+
+  useEffect(() => {
+    dispatch(profileActions.getAllInventoriesForUser());
+  }, []);
 
   return (
     <Box>

--- a/frontend/src/Components/Inventory/Inventories.jsx
+++ b/frontend/src/Components/Inventory/Inventories.jsx
@@ -1,10 +1,10 @@
-import { Box, Container, Dialog, Tab, Tabs, Tooltip, makeStyles } from '@material-ui/core';
+import { Box, Dialog, Tab, Tabs, Tooltip, makeStyles } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import TextComponent from '../../stories/TextComponent/TextComponent';
 import { AddRounded, CancelRounded, DoneRounded } from '@material-ui/icons';
 import ButtonComponent from '../../stories/Button/ButtonComponent';
 import EasyEdit, { Types } from 'react-easy-edit';
-import { INVENTORY_TABS, VIEW_PERSONAL_INVENTORY_LIST_HEADERS } from './constants';
+import { INVENTORY_TABS, VIEW_PERSONAL_INVENTORY_COLUMNS, VIEW_PERSONAL_INVENTORY_LIST_HEADERS } from './constants';
 import Title from '../DialogComponent/Title';
 import AddItemDetail from '../ItemDetail/AddItemDetail';
 import List from '../DrawerListComponent/List';
@@ -40,6 +40,7 @@ const Inventories = () => {
   const dispatch = useDispatch();
   const [value, setValue] = useState(0);
   const [editMode, setEditMode] = useState(false);
+  const [displayData, setDisplayData] = useState([]);
 
   const { loading: inventoriesLoading, inventories } = useSelector((state) => state.profile);
 
@@ -47,60 +48,27 @@ const Inventories = () => {
     setEditMode(!editMode);
     dispatch(eventActions.getStorageLocations());
   };
+
   const handleChange = (event, newValue) => {
     setValue(newValue);
+    const selectionMenu = {
+      1: 'COUPONS',
+      2: 'DRAFT',
+      3: 'HIDDEN',
+    };
+    const currentSelectedCriteria = selectionMenu[newValue];
+    const formattedData =
+      (currentSelectedCriteria && inventories.filter((v) => v.status === currentSelectedCriteria)) || inventories;
+    setDisplayData([...formattedData]);
   };
 
-  const data = [
-    {
-      id: '5a271435-a055-45b9-9481-97b41e5a4d05',
-      name: 'Dog food',
-      description: 'Large breed dog food for tiku',
-      price: '89.99',
-      status: 'COUPONS', // [COUPONS, HIDDEN, DRAFT]
-      barcode: '',
-      sku: '',
-      quantity: 1,
-      location: 'Kitchen Pantry',
-      created_at: '2024-03-17T15:55:02.701296Z',
-      created_by: '71759d26-8128-4b30-abb3-b84f63439bf3',
-      creator_name: 'Native Plants',
-      updated_at: '2024-03-17T15:55:02.701296Z',
-      updated_by: '71759d26-8128-4b30-abb3-b84f63439bf3',
-      updater_name: 'Native Plants',
-      storage_location_id: 'efc8e1f6-9462-492c-9ce6-821bdb591fea',
-      bought_at: 'Walmart',
-    },
-    {
-      id: '5a271435-a055-45b9-9481-97b41e5a4d05',
-      name: 'Dog food',
-      description: 'Large breed dog food for tiku',
-      price: '89.99',
-      status: 'HIDDEN', // [COUPONS, HIDDEN, DRAFT]
-      barcode: '',
-      sku: '',
-      quantity: 1,
-      location: 'Kitchen Pantry',
-      created_at: '2024-03-17T15:55:02.701296Z',
-      created_by: '71759d26-8128-4b30-abb3-b84f63439bf3',
-      creator_name: 'Native Plants',
-      updated_at: '2024-03-17T15:55:02.701296Z',
-      updated_by: '71759d26-8128-4b30-abb3-b84f63439bf3',
-      updater_name: 'Native Plants',
-      storage_location_id: 'efc8e1f6-9462-492c-9ce6-821bdb591fea',
-      bought_at: 'Walmart',
-    },
-  ];
-
-  const columns = Object.keys(data.length > 0 && data[0]); // for header purpose
-  // removing unwanted values from the display column
-  const filteredItems = data?.map((item) => {
+  const filteredItems = displayData?.map((item) => {
     const { id, eventID, storage_location_id, created_by, updated_by, ...rest } = item;
     return rest;
   });
 
   const columnHeaderFormatter = (column) => {
-    const header = VIEW_PERSONAL_INVENTORY_LIST_HEADERS[column];
+    const header = VIEW_PERSONAL_INVENTORY_COLUMNS[column];
     // Apply a modifier function if defined
     const formattedTitle = header?.modifier ? header.modifier(header.title) : header?.displayName;
     return formattedTitle;
@@ -132,67 +100,63 @@ const Inventories = () => {
     return row[column];
   };
 
-  const displaySelection = (value) => {
+  const displaySelection = (value, data) => {
     switch (value) {
       case 0:
         return (
-          <Container maxWidth="lg">
-            <List
-              tooltipTitle={'Download all items '}
-              fileName={'inventories.xlsx'}
-              sheetName={'All Inventories'}
-              data={data}
-              columns={columns}
-              filteredData={filteredItems}
-              columnHeaderFormatter={columnHeaderFormatter}
-              rowFormatter={rowFormatter}
-            />
-          </Container>
+          <List
+            key={performance.now()}
+            tooltipTitle={'Download all items '}
+            fileName={'inventories.xlsx'}
+            sheetName={'All Inventories'}
+            data={displayData}
+            columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
+            filteredData={filteredItems}
+            columnHeaderFormatter={columnHeaderFormatter}
+            rowFormatter={rowFormatter}
+          />
         );
       case 1:
         return (
-          <Container maxWidth="lg">
-            <List
-              tooltipTitle={'Download all items with coupons '}
-              fileName={'inventories.xlsx'}
-              sheetName={'Coupons'}
-              data={data.filter((v) => v.status === 'COUPONS')}
-              columns={columns}
-              filteredData={filteredItems}
-              columnHeaderFormatter={columnHeaderFormatter}
-              rowFormatter={rowFormatter}
-            />
-          </Container>
+          <List
+            key={performance.now()}
+            tooltipTitle={'Download all items with coupons '}
+            fileName={'inventories.xlsx'}
+            sheetName={'Coupons'}
+            data={displayData}
+            columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
+            filteredData={filteredItems}
+            columnHeaderFormatter={columnHeaderFormatter}
+            rowFormatter={rowFormatter}
+          />
         );
       case 2:
         return (
-          <Container maxWidth="lg">
-            <List
-              tooltipTitle={'Download all items with draft status '}
-              fileName={'inventories.xlsx'}
-              sheetName={'Draft Status'}
-              data={data.filter((v) => v.status === 'DRAFT')}
-              columns={columns}
-              filteredData={filteredItems}
-              columnHeaderFormatter={columnHeaderFormatter}
-              rowFormatter={rowFormatter}
-            />
-          </Container>
+          <List
+            key={performance.now()}
+            tooltipTitle={'Download all items with draft status '}
+            fileName={'inventories.xlsx'}
+            sheetName={'Draft Status'}
+            data={displayData}
+            columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
+            filteredData={filteredItems}
+            columnHeaderFormatter={columnHeaderFormatter}
+            rowFormatter={rowFormatter}
+          />
         );
       case 3:
         return (
-          <Container maxWidth="lg">
-            <List
-              tooltipTitle={'Download all inventories with hidden status '}
-              fileName={'inventories.xlsx'}
-              sheetName={'Hidden Inventories'}
-              data={data.filter((v) => v.status === 'HIDDEN')}
-              columns={columns}
-              filteredData={filteredItems}
-              columnHeaderFormatter={columnHeaderFormatter}
-              rowFormatter={rowFormatter}
-            />
-          </Container>
+          <List
+            key={performance.now()}
+            tooltipTitle={'Download all inventories with hidden status '}
+            fileName={'inventories.xlsx'}
+            sheetName={'Hidden Inventories'}
+            data={displayData}
+            columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
+            filteredData={filteredItems}
+            columnHeaderFormatter={columnHeaderFormatter}
+            rowFormatter={rowFormatter}
+          />
         );
       default:
         return null;
@@ -202,6 +166,12 @@ const Inventories = () => {
   useEffect(() => {
     dispatch(profileActions.getAllInventoriesForUser());
   }, []);
+
+  useEffect(() => {
+    if (Array.isArray(inventories)) {
+      setDisplayData(inventories);
+    }
+  }, [inventoriesLoading]);
 
   return (
     <Box>

--- a/frontend/src/Components/Inventory/Inventories.jsx
+++ b/frontend/src/Components/Inventory/Inventories.jsx
@@ -4,7 +4,7 @@ import TextComponent from '../../stories/TextComponent/TextComponent';
 import { AddRounded, CancelRounded, DoneRounded } from '@material-ui/icons';
 import ButtonComponent from '../../stories/Button/ButtonComponent';
 import EasyEdit, { Types } from 'react-easy-edit';
-import { INVENTORY_TABS, VIEW_PERSONAL_INVENTORY_COLUMNS, VIEW_PERSONAL_INVENTORY_LIST_HEADERS } from './constants';
+import { ADD_ITEM_PROFILE_FORM, ADD_NEW_INVENTORY_SUBTITLE_TEXT, INVENTORY_TABS, VIEW_PERSONAL_INVENTORY_COLUMNS } from './constants';
 import Title from '../DialogComponent/Title';
 import AddItemDetail from '../ItemDetail/AddItemDetail';
 import List from '../DrawerListComponent/List';
@@ -67,13 +67,6 @@ const Inventories = () => {
     return rest;
   });
 
-  const columnHeaderFormatter = (column) => {
-    const header = VIEW_PERSONAL_INVENTORY_COLUMNS[column];
-    // Apply a modifier function if defined
-    const formattedTitle = header?.modifier ? header.modifier(header.title) : header?.displayName;
-    return formattedTitle;
-  };
-
   const rowFormatter = (row, column, rowIndex) => {
     // if any of the row includes timestamp we modify it
     if (['created_at', 'updated_at'].includes(column)) {
@@ -101,32 +94,37 @@ const Inventories = () => {
   };
 
   const displaySelection = (value, data) => {
+    const tableOptions = {
+      filterType: 'checkbox',
+      // customRowRender: rowFormatter
+    };
+
     switch (value) {
       case 0:
         return (
           <List
             key={performance.now()}
+            tableTitle={'All Products'}
             tooltipTitle={'Download all items '}
             fileName={'inventories.xlsx'}
             sheetName={'All Inventories'}
             data={displayData}
             columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
             filteredData={filteredItems}
-            columnHeaderFormatter={columnHeaderFormatter}
-            rowFormatter={rowFormatter}
+            tableOptions={tableOptions}
           />
         );
       case 1:
         return (
           <List
             key={performance.now()}
+            tableTitle={'Coupons / Deals'}
             tooltipTitle={'Download all items with coupons '}
             fileName={'inventories.xlsx'}
             sheetName={'Coupons'}
             data={displayData}
             columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
             filteredData={filteredItems}
-            columnHeaderFormatter={columnHeaderFormatter}
             rowFormatter={rowFormatter}
           />
         );
@@ -134,27 +132,25 @@ const Inventories = () => {
         return (
           <List
             key={performance.now()}
-            tooltipTitle={'Download all items with draft status '}
+            tableTitle={'Draft'}
             fileName={'inventories.xlsx'}
             sheetName={'Draft Status'}
             data={displayData}
             columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
             filteredData={filteredItems}
-            columnHeaderFormatter={columnHeaderFormatter}
-            rowFormatter={rowFormatter}
           />
         );
       case 3:
         return (
           <List
             key={performance.now()}
+            tableTitle={'Hidden'}
             tooltipTitle={'Download all inventories with hidden status '}
             fileName={'inventories.xlsx'}
             sheetName={'Hidden Inventories'}
             data={displayData}
             columns={VIEW_PERSONAL_INVENTORY_COLUMNS}
             filteredData={filteredItems}
-            columnHeaderFormatter={columnHeaderFormatter}
             rowFormatter={rowFormatter}
           />
         );
@@ -189,7 +185,11 @@ const Inventories = () => {
       {editMode && (
         <Dialog open width={'md'} fullWidth={true}>
           <Title onClose={() => setEditMode(false)}>Add New Item</Title>
-          <AddItemDetail eventID={''} setDisplayMode={setEditMode} />
+          <AddItemDetail
+            setDisplayMode={setEditMode}
+            draftFormFields={ADD_ITEM_PROFILE_FORM}
+            subtitleText={ADD_NEW_INVENTORY_SUBTITLE_TEXT}
+          />
         </Dialog>
       )}
       <Tabs value={value} onChange={handleChange} indicatorColor="primary" textColor="primary">

--- a/frontend/src/Components/Inventory/constants.jsx
+++ b/frontend/src/Components/Inventory/constants.jsx
@@ -1,107 +1,204 @@
 import { AllInboxRounded, DraftsRounded, LoyaltyRounded, VisibilityOffRounded } from '@material-ui/icons';
 
 export const INVENTORY_TABS = [
-    {
-      id: 1,
-      icon: <AllInboxRounded />,
-      tootipTitle: 'Displays products that are not hidden',
-      label: 'All products',
-    },
-    {
-      id: 2,
-      icon: <LoyaltyRounded />,
-      tootipTitle: 'Displays products that were labelled as bought in sale',
-      label: 'Coupons / Deals',
-    },
-    {
-      id: 3,
-      icon: <DraftsRounded />,
-      tootipTitle: 'Displays all products labelled as draft / published',
-      label: 'Draft / Published',
-    },
-    {
-      id: 4,
-      icon: <VisibilityOffRounded />,
-      tootipTitle: 'Displays all products with hidden status',
-      label: 'Hidden status',
-    },
-  ];
+  {
+    id: 1,
+    icon: <AllInboxRounded />,
+    tootipTitle: 'Displays products that are not hidden',
+    label: 'All products',
+  },
+  {
+    id: 2,
+    icon: <LoyaltyRounded />,
+    tootipTitle: 'Displays products that were labelled as bought in sale',
+    label: 'Coupons / Deals',
+  },
+  {
+    id: 3,
+    icon: <DraftsRounded />,
+    tootipTitle: 'Displays all products labelled as draft / published',
+    label: 'Draft / Published',
+  },
+  {
+    id: 4,
+    icon: <VisibilityOffRounded />,
+    tootipTitle: 'Displays all products with hidden status',
+    label: 'Hidden status',
+  },
+];
 
+export const VIEW_PERSONAL_INVENTORY_COLUMNS = [
+  {
+    name: 'name',
+    label: 'Name',
+    options: {
+      filter: false,
+      sort: true,
+    },
+  },
+  {
+    name: 'description',
+    label: 'Description',
+    options: {
+      filter: false,
+      sort: false,
+    },
+  },
+  {
+    name: 'price',
+    label: 'Price',
+    options: {
+      filter: false,
+      sort: true,
+    },
+  },
+  {
+    name: 'status',
+    label: 'Status',
+    options: {
+      filter: true,
+      sort: true,
+    },
+  },
+  {
+    name: 'barcode',
+    label: 'BarCode',
+    options: {
+      filter: false,
+      sort: false,
+    },
+  },
+  {
+    name: 'sku',
+    label: 'SKU',
+    options: {
+      filter: false,
+      sort: false,
+    },
+  },
+  {
+    name: 'quantity',
+    label: 'Count',
+    options: {
+      filter: false,
+      sort: false,
+    },
+  },
+  {
+    name: 'location',
+    label: 'Location',
+    options: {
+      filter: true,
+      sort: true,
+    },
+  },
+  {
+    name: 'created_at',
+    label: 'Created At',
+    options: {
+      filter: false,
+      sort: true,
+    },
+  },
+  {
+    name: 'creator_name',
+    label: 'Creator',
+    options: {
+      filter: true,
+      sort: false,
+    },
+  },
+  {
+    name: 'updated_at',
+    label: 'Updated At',
+    options: {
+      filter: false,
+      sort: true,
+    },
+  },
+  {
+    name: 'updater_name',
+    label: 'Updator',
+    options: {
+      filter: true,
+      sort: false,
+    },
+  },
+];
 
-  export const VIEW_PERSONAL_INVENTORY_LIST_HEADERS = {
-    name: {
-      key: 'name',
-      title: 'Item name',
-      displayName: 'Item name',
-    },
-    description: {
-      key: 'item_description',
-      title: 'Item Description',
-      displayName: 'Description',
-    },
-    price: {
-      key: 'price',
-      title: 'Cost',
-      displayName: 'Cost Per Unit',
-      modifier: (title) => `${title}`,
-    },
-    status: {
-      key: 'status',
-      title: 'Status',
-      displayName: 'Item Status',
-      modifier: (title) => `${title}`,
-    },
-    barcode: {
-      key: 'barcode',
-      title: 'Barcode',
-      displayName: 'Barcode',
-      modifier: (title) => `${title}`,
-    },
-    sku: {
-      key: 'SKU',
-      title: 'SKU',
-      displayName: 'SKU',
-    },
-    quantity: {
-      key: 'quantity',
-      title: 'Quantity',
-      displayName: 'Item Quantity',
-      modifier: (title) => `${title}`,
-    },
-    created_at: {
-      key: 'created_at',
-      title: 'Created At',
-      displayName: 'Creation Date',
-    },
-    updated_at: {
-      key: 'updated_at',
-      title: 'Updated At',
-      displayName: 'Update Date',
-    },
-    location: {
-      key: 'location',
-      title: 'Storage Location',
-      displayName: 'Location',
-    },
-    item_detail: {
-      key: 'item_detail',
-      title: 'Item Detail',
-      displayName: 'Item Details',
-    },
-    bought_at: {
-      key: 'bought_at',
-      title: 'Bought At',
-      displayName: 'Purchase Location',
-    },
-    creator_name: {
-      key: 'creator_name',
-      title: 'Creator Name',
-      displayName: 'Creator',
-    },
-    updater_name: {
-      key: 'updater_name',
-      title: 'Updator Name',
-      displayName: 'Updater',
-    },
-  };
-  
+export const VIEW_PERSONAL_INVENTORY_LIST_HEADERS = {
+  name: {
+    key: 'name',
+    title: 'Item name',
+    displayName: 'Item name',
+  },
+  description: {
+    key: 'item_description',
+    title: 'Item Description',
+    displayName: 'Description',
+  },
+  price: {
+    key: 'price',
+    title: 'Cost',
+    displayName: 'Cost Per Unit',
+    modifier: (title) => `${title}`,
+  },
+  status: {
+    key: 'status',
+    title: 'Status',
+    displayName: 'Item Status',
+    modifier: (title) => `${title}`,
+  },
+  barcode: {
+    key: 'barcode',
+    title: 'Barcode',
+    displayName: 'Barcode',
+    modifier: (title) => `${title}`,
+  },
+  sku: {
+    key: 'SKU',
+    title: 'SKU',
+    displayName: 'SKU',
+  },
+  quantity: {
+    key: 'quantity',
+    title: 'Quantity',
+    displayName: 'Item Quantity',
+    modifier: (title) => `${title}`,
+  },
+  created_at: {
+    key: 'created_at',
+    title: 'Created At',
+    displayName: 'Creation Date',
+  },
+  updated_at: {
+    key: 'updated_at',
+    title: 'Updated At',
+    displayName: 'Update Date',
+  },
+  location: {
+    key: 'location',
+    title: 'Storage Location',
+    displayName: 'Location',
+  },
+  item_detail: {
+    key: 'item_detail',
+    title: 'Item Detail',
+    displayName: 'Item Details',
+  },
+  bought_at: {
+    key: 'bought_at',
+    title: 'Bought At',
+    displayName: 'Purchase Location',
+  },
+  creator_name: {
+    key: 'creator_name',
+    title: 'Creator Name',
+    displayName: 'Creator',
+  },
+  updater_name: {
+    key: 'updater_name',
+    title: 'Updator Name',
+    displayName: 'Updater',
+  },
+};

--- a/frontend/src/Components/Inventory/constants.jsx
+++ b/frontend/src/Components/Inventory/constants.jsx
@@ -1,31 +1,183 @@
 import { AllInboxRounded, DraftsRounded, LoyaltyRounded, VisibilityOffRounded } from '@material-ui/icons';
 
+export const ADD_NEW_INVENTORY_SUBTITLE_TEXT =
+  'Add items for your own inventory. Store items under here that are for your personal use. All Items stored with due process until the user profile is abandoned.';
+
 export const INVENTORY_TABS = [
   {
     id: 1,
     icon: <AllInboxRounded />,
-    tootipTitle: 'Displays products that are not hidden',
+    tootipTitle: 'Displays inventory items',
     label: 'All products',
   },
   {
     id: 2,
     icon: <LoyaltyRounded />,
-    tootipTitle: 'Displays products that were labelled as bought in sale',
+    tootipTitle: 'Displays inventory items that were labelled as bought in sale',
     label: 'Coupons / Deals',
   },
   {
     id: 3,
     icon: <DraftsRounded />,
-    tootipTitle: 'Displays all products labelled as draft / published',
-    label: 'Draft / Published',
+    tootipTitle: 'Displays all inventory items labelled as draft',
+    label: 'Draft',
   },
   {
     id: 4,
     icon: <VisibilityOffRounded />,
-    tootipTitle: 'Displays all products with hidden status',
+    tootipTitle: 'Displays all inventory items with hidden status',
     label: 'Hidden status',
   },
 ];
+
+const GENERIC_FORM_FIELDS_VARIANT = {
+  type: 'text',
+  variant: 'standard',
+};
+
+export const GENERIC_TEXTAREA_VARIANT = {
+  type: 'text',
+  multiline: true,
+  rows: 4,
+  variant: 'outlined',
+  fullWidth: true,
+};
+
+/**
+ * ADD ITEM PROFILE FORM. 
+ * 
+ * Used to add new item in user's personal profile.
+ */
+export const ADD_ITEM_PROFILE_FORM = {
+  name: {
+    label: 'Item Name',
+    placeholder: 'Enter product name',
+    value: '',
+    name: 'name',
+    errorMsg: '',
+    required: true,
+    fullWidth: true,
+    validators: [
+      {
+        validate: (value) => value.trim().length === 0,
+        message: 'Name is required',
+      },
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'Name should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+  description: {
+    label: 'Item description',
+    placeholder: '',
+    value: '',
+    name: 'description',
+    errorMsg: '',
+    required: false,
+    fullWidth: true,
+    validators: [
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'Description should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_TEXTAREA_VARIANT,
+  },
+  price: {
+    label: 'Price',
+    placeholder: '',
+    value: '',
+    name: 'price',
+    errorMsg: '',
+    required: true,
+    fullWidth: false,
+    validators: [
+      {
+        validate: (value) => value.trim().length === 0,
+        message: 'Price for the selected item is required',
+      },
+      {
+        validate: (value) =>
+          // test for number first, then
+          !(/^\d+$/.test(value) && parseInt(value) > 0),
+        message: 'A positive number is required',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+  barcode: {
+    label: 'Item barcode',
+    placeholder: '',
+    value: '',
+    name: 'barcode',
+    errorMsg: '',
+    required: false,
+    fullWidth: false,
+    validators: [
+      {
+        validate: (value) => value.trim().length >= 100,
+        message: 'barcode should be less than 100 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+  sku: {
+    label: 'Item sku',
+    placeholder: '',
+    value: '',
+    name: 'sku',
+    errorMsg: '',
+    required: false,
+    fullWidth: true,
+    validators: [
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'sku should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+  quantity: {
+    label: 'Quantity',
+    placeholder: '',
+    value: '',
+    name: 'quantity',
+    errorMsg: '',
+    required: true,
+    fullWidth: false,
+    validators: [
+      {
+        validate: (value) => value.trim().length === 0,
+        message: 'Quantity for the selected item is required',
+      },
+      {
+        validate: (value) =>
+          // test for number first, then
+          !(/^\d+$/.test(value) && parseInt(value) > 0),
+        message: 'A positive number is required',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+  bought_at: {
+    label: 'Place of purchase',
+    placeholder: '',
+    value: '',
+    name: 'bought_at',
+    errorMsg: '',
+    required: false,
+    fullWidth: false,
+    validators: [
+      {
+        validate: (value) => value.trim().length >= 50,
+        message: 'Place of purchase should be less than 50 characters',
+      },
+    ],
+    ...GENERIC_FORM_FIELDS_VARIANT,
+  },
+};
 
 export const VIEW_PERSONAL_INVENTORY_COLUMNS = [
   {
@@ -125,80 +277,3 @@ export const VIEW_PERSONAL_INVENTORY_COLUMNS = [
     },
   },
 ];
-
-export const VIEW_PERSONAL_INVENTORY_LIST_HEADERS = {
-  name: {
-    key: 'name',
-    title: 'Item name',
-    displayName: 'Item name',
-  },
-  description: {
-    key: 'item_description',
-    title: 'Item Description',
-    displayName: 'Description',
-  },
-  price: {
-    key: 'price',
-    title: 'Cost',
-    displayName: 'Cost Per Unit',
-    modifier: (title) => `${title}`,
-  },
-  status: {
-    key: 'status',
-    title: 'Status',
-    displayName: 'Item Status',
-    modifier: (title) => `${title}`,
-  },
-  barcode: {
-    key: 'barcode',
-    title: 'Barcode',
-    displayName: 'Barcode',
-    modifier: (title) => `${title}`,
-  },
-  sku: {
-    key: 'SKU',
-    title: 'SKU',
-    displayName: 'SKU',
-  },
-  quantity: {
-    key: 'quantity',
-    title: 'Quantity',
-    displayName: 'Item Quantity',
-    modifier: (title) => `${title}`,
-  },
-  created_at: {
-    key: 'created_at',
-    title: 'Created At',
-    displayName: 'Creation Date',
-  },
-  updated_at: {
-    key: 'updated_at',
-    title: 'Updated At',
-    displayName: 'Update Date',
-  },
-  location: {
-    key: 'location',
-    title: 'Storage Location',
-    displayName: 'Location',
-  },
-  item_detail: {
-    key: 'item_detail',
-    title: 'Item Detail',
-    displayName: 'Item Details',
-  },
-  bought_at: {
-    key: 'bought_at',
-    title: 'Bought At',
-    displayName: 'Purchase Location',
-  },
-  creator_name: {
-    key: 'creator_name',
-    title: 'Creator Name',
-    displayName: 'Creator',
-  },
-  updater_name: {
-    key: 'updater_name',
-    title: 'Updator Name',
-    displayName: 'Updater',
-  },
-};

--- a/frontend/src/Components/Notes/NotesDetails.jsx
+++ b/frontend/src/Components/Notes/NotesDetails.jsx
@@ -133,7 +133,7 @@ const NotesDetails = () => {
   }, [loading]);
 
   if (loading) {
-    return <LoadingSkeleton height={'10rem'} width={'10rem'} />;
+    return <LoadingSkeleton width={`calc(100% - 1rem)`} height={'2rem'} />;
   }
 
   if (!notes || notes.length === 0) {

--- a/frontend/src/Components/Notes/constants.jsx
+++ b/frontend/src/Components/Notes/constants.jsx
@@ -1,6 +1,6 @@
 const GENERIC_FORM_FIELDS = {
   type: 'text',
-  variant: 'static',
+  variant: 'standard',
 };
 
 const GENERIC_TEXTAREA_VARIANT = {

--- a/frontend/src/Components/ViewProfileDetails/UserProfile.jsx
+++ b/frontend/src/Components/ViewProfileDetails/UserProfile.jsx
@@ -15,7 +15,6 @@ const useStyles = makeStyles((theme) => ({
     gap: '1.2rem',
     textOverflow: 'ellipsis',
     textWrap: 'wrap',
-    width: `calc(100% - 40rem)`,
     [theme.breakpoints.down('sm')]: {
       width: `26rem`,
     },

--- a/frontend/src/Containers/Event/EventPage.jsx
+++ b/frontend/src/Containers/Event/EventPage.jsx
@@ -11,9 +11,7 @@ const EventPage = () => {
     <ThemeProvider theme={primary_theme}>
       <CssBaseline />
       <PrimaryAppBar selectedID={1} />
-      <Container maxWidth="lg">
-        <EventDetailPage />
-      </Container>
+      <EventDetailPage />
     </ThemeProvider>
   );
 };

--- a/frontend/src/Containers/Profile/ProfilePage.jsx
+++ b/frontend/src/Containers/Profile/ProfilePage.jsx
@@ -7,9 +7,7 @@ const ProfilePage = () => {
     <ThemeProvider theme={primary_theme}>
       <CssBaseline />
       <PrimaryAppBar selectedID={2} />
-      <Container maxWidth="xl">
-        <ProfileDetailPage />
-      </Container>
+      <ProfileDetailPage />
     </ThemeProvider>
   );
 };

--- a/frontend/src/Containers/Profile/profileSaga.js
+++ b/frontend/src/Containers/Profile/profileSaga.js
@@ -25,6 +25,16 @@ export function* fetchRecentActivitiesList() {
   }
 }
 
+export function* fetchAllInventoriesForUser() {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.get, `${BASEURL}/${USER_ID}/inventories`);
+    yield put(profileActions.getAllInventoriesForUserSuccess(response.data || []));
+  } catch (e) {
+    yield put(profileActions.getAllInventoriesForUserFailure(e));
+  }
+}
+
 export function* fetchRecentActivitiesTrophyList() {
   try {
     const USER_ID = localStorage.getItem('userID');
@@ -187,6 +197,10 @@ export function* watchFetchVolunteeringDetails() {
   yield takeLatest(`profile/getVolunteeringDetails`, fetchVolunteeringDetails);
 }
 
+export function* watchFetchAllInventoriesForUser() {
+  yield takeLatest(`profile/getAllInventoriesForUser`, fetchAllInventoriesForUser);
+}
+
 export function* watchFetchUpdateProfileImage() {
   yield takeEvery(`profile/updateProfileImage`, fetchUpdateProfileImage);
 }
@@ -197,6 +211,7 @@ export default [
   watchFetchAddNewNote,
   watchFetchUpdateExistingNote,
   watchFetchRemoveSelectedNote,
+  watchFetchAllInventoriesForUser,
   watchExistingNotificationsUserDetails,
   watchFetchRecentActivitiesTrophyList,
   watchFetchRecentActivitiesList,

--- a/frontend/src/Containers/Profile/profileSaga.js
+++ b/frontend/src/Containers/Profile/profileSaga.js
@@ -15,6 +15,40 @@ export function* fetchExistingUserDetails() {
   }
 }
 
+export function* fetchUpdateProfileImage(action) {
+  try {
+    const { selectedImage, userID } = action.payload;
+
+    const formData = new FormData();
+    formData.append('avatarSrc', selectedImage);
+    const response = yield call(instance.post, `${BASEURL}/${userID}/updateAvatar`, formData);
+    yield put(profileActions.updateProfileImageSuccess(response.data));
+  } catch (e) {
+    yield put(profileActions.updateProfileImageFailure(e));
+  }
+}
+
+export function* updateExistingUserDetails(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const { formattedData } = action.payload;
+    const response = yield call(instance.put, `${BASEURL}/${USER_ID}`, {
+      username: formattedData.username,
+      full_name: formattedData.name,
+      avatar_url: formattedData.avatarUrl,
+      email_address: formattedData.email,
+      phone_number: formattedData.phone,
+      goal: formattedData.objective,
+      about_me: formattedData.aboutMe,
+      online_status: formattedData.onlineStatus,
+      role: formattedData.role,
+    });
+    yield put(profileActions.getProfileDetailsSuccess(response.data));
+  } catch (e) {
+    yield put(profileActions.getProfileDetailsFailure(e));
+  }
+}
+
 export function* fetchRecentActivitiesList() {
   try {
     const USER_ID = localStorage.getItem('userID');
@@ -52,27 +86,6 @@ export function* fetchExistingNotificationsUserDetails() {
     yield put(profileActions.getProfileNotificationsSuccess(response.data));
   } catch (e) {
     yield put(profileActions.getProfileNotificationsFailure(e));
-  }
-}
-
-export function* updateExistingUserDetails(action) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const { formattedData } = action.payload;
-    const response = yield call(instance.put, `${BASEURL}/${USER_ID}`, {
-      username: formattedData.username,
-      full_name: formattedData.name,
-      avatar_url: formattedData.avatarUrl,
-      email_address: formattedData.email,
-      phone_number: formattedData.phone,
-      goal: formattedData.objective,
-      about_me: formattedData.aboutMe,
-      online_status: formattedData.onlineStatus,
-      role: formattedData.role,
-    });
-    yield put(profileActions.getProfileDetailsSuccess(response.data));
-  } catch (e) {
-    yield put(profileActions.getProfileDetailsFailure(e));
   }
 }
 
@@ -140,16 +153,13 @@ export function* fetchRemoveSelectedNote(action) {
   }
 }
 
-export function* fetchUpdateProfileImage(action) {
+export function* fetchAddNewInventory(action) {
   try {
-    const { selectedImage, userID } = action.payload;
-
-    const formData = new FormData();
-    formData.append('avatarSrc', selectedImage);
-    const response = yield call(instance.post, `${BASEURL}/${userID}/updateAvatar`, formData);
-    yield put(profileActions.updateProfileImageSuccess(response.data));
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventory`, { ...action.payload });
+    yield put(profileActions.addInventorySuccess(response.data));
   } catch (e) {
-    yield put(profileActions.updateProfileImageFailure(e));
+    yield put(profileActions.addInventoryFailure(e));
   }
 }
 
@@ -181,6 +191,10 @@ export function* watchFetchExistingUserDetails() {
   yield takeLatest(`profile/getProfileDetails`, fetchExistingUserDetails);
 }
 
+export function* watchFetchAddNewInventory() {
+  yield takeLatest(`profile/addInventory`, fetchAddNewInventory);
+}
+
 export function* watchFetchRecentActivitiesList() {
   yield takeLatest(`profile/getRecentActivitiesList`, fetchRecentActivitiesList);
 }
@@ -209,6 +223,7 @@ export function* watchFetchUpdateProfileImage() {
 export default [
   watchGetUserNotes,
   watchFetchAddNewNote,
+  watchFetchAddNewInventory,
   watchFetchUpdateExistingNote,
   watchFetchRemoveSelectedNote,
   watchFetchAllInventoriesForUser,

--- a/frontend/src/Containers/Profile/profileSlice.js
+++ b/frontend/src/Containers/Profile/profileSlice.js
@@ -150,6 +150,22 @@ const profileSlice = createSlice({
       state.error = '';
       state.inventories = [];
     },
+    addInventory: (state) => {
+      state.loading = true;
+      state.error = '';
+      state.inventories = [];
+    },
+    addInventorySuccess: (state, action) => {
+      const updatedValues = action.payload;
+      state.loading = false;
+      state.error = '';
+      state.inventories = [...state.inventories, updatedValues];
+    },
+    addInventoryFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
     getUserNotes: (state) => {
       state.loading = true;
       state.error = '';

--- a/frontend/src/Containers/Profile/profileSlice.js
+++ b/frontend/src/Containers/Profile/profileSlice.js
@@ -5,6 +5,7 @@ const initialState = {
   error: '',
   profileDetails: {},
   notifications: [],
+  inventories: [],
   volunteeringDetails: [],
   recentActivities: [],
   recentTrophies: {},
@@ -133,6 +134,21 @@ const profileSlice = createSlice({
       state.loading = false;
       state.error = '';
       state.volunteeringDetails = [];
+    },
+    getAllInventoriesForUser: (state) => {
+      state.loading = true;
+      state.error = '';
+      state.inventories = [];
+    },
+    getAllInventoriesForUserSuccess: (state, action) => {
+      state.inventories = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    getAllInventoriesForUserFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
     },
     getUserNotes: (state) => {
       state.loading = true;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1548,6 +1548,14 @@
   resolved "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
+"@babel/runtime-corejs3@^7.12.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz#f39707b213441dec645ce8285ae14f281a5077c6"
+  integrity sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==
+  dependencies:
+    core-js-pure "^3.30.2"
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.23.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz"
@@ -1559,6 +1567,13 @@
   version "7.24.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz"
   integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.7.2":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.1.tgz#431f9a794d173b53720e69a6464abc6f0e2a5c57"
+  integrity sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -2925,6 +2940,21 @@
   integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@react-dnd/asap@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-4.0.1.tgz#5291850a6b58ce6f2da25352a64f1b0674871aab"
+  integrity sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==
+
+"@react-dnd/invariant@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-2.0.0.tgz#09d2e81cd39e0e767d7da62df9325860f24e517e"
+  integrity sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==
+
+"@react-dnd/shallowequal@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz#a3031eb54129f2c66b2753f8404266ec7bf67f0a"
+  integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
 
 "@reactour/mask@*":
   version "1.1.0"
@@ -6250,7 +6280,7 @@ clone@^1.0.2:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-clsx@^1.0.4, clsx@^1.1.0:
+clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -6480,6 +6510,11 @@ core-js-pure@^3.23.3:
   version "3.33.2"
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.2.tgz"
   integrity sha512-a8zeCdyVk7uF2elKIGz67AjcXOxjRbwOLz8SbklEso1V+2DoW4OkAMZN9S9GBgvZIaqQi/OemFX4OiSoQEmg1Q==
+
+core-js-pure@^3.30.2:
+  version "3.36.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.36.1.tgz#1461c89e76116528b54eba20a0aff30164087a94"
+  integrity sha512-NXCvHvSVYSrewP0L5OhltzXeWFJLo2AL2TYnj6iLV3Bw8mM62wAQMNgUCRI6EBu6hVVpbCxmOPlxh1Ikw2PfUA==
 
 core-js@^3.19.2:
   version "3.33.2"
@@ -7099,6 +7134,15 @@ dlv@^1.1.3:
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnd-core@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-11.1.3.tgz#f92099ba7245e49729d2433157031a6267afcc98"
+  integrity sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==
+  dependencies:
+    "@react-dnd/asap" "^4.0.0"
+    "@react-dnd/invariant" "^2.0.0"
+    redux "^4.0.4"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"
@@ -7142,7 +7186,7 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -8371,6 +8415,19 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+frontend-collective-react-dnd-scrollzone@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/frontend-collective-react-dnd-scrollzone/-/frontend-collective-react-dnd-scrollzone-1.0.2.tgz#cf5ed6165335f7d26504a40126f8e972ee644698"
+  integrity sha512-me/D9PZJq9j/sjEjs/OPmm6V6nbaHbhgeQiwrWu0t35lhwAOKWc+QBzzKKcZQeboYTkgE8UvCD9el+5ANp+g5Q==
+  dependencies:
+    hoist-non-react-statics "^3.1.0"
+    lodash.throttle "^4.0.1"
+    prop-types "^15.5.9"
+    raf "^3.2.0"
+    react "^16.3.0"
+    react-display-name "^0.2.0"
+    react-dom "^16.3.0"
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
@@ -8819,7 +8876,7 @@ hoist-non-react-statics@^1.0.3:
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
   integrity sha512-r8huvKK+m+VraiRipdZYc+U4XW43j6OFG/oIafe7GfDbRpCduRoX9JI/DRxqgtBSCeL+et6N6ibZoedHS2NyOQ==
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10508,10 +10565,30 @@ lodash._getnative@^3.0.0:
   resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
   integrity sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==
 
+lodash.assignwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
+  integrity sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.find@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+  integrity sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -10531,10 +10608,20 @@ lodash.isequal@^3.0.4:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz"
   integrity sha512-lGWJ6N8AA3KSv+ZZxlTdn4f6A7kMfpJboeyvbFdE7IU9YAgweODqmOgdUHOA+c6lVWeVLysdaxciFXi+foVsWw==
+
+lodash.isundefined@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
+  integrity sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -10559,6 +10646,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
+
+lodash.throttle@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -10898,6 +10990,28 @@ ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mui-datatables@^3.8.0:
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/mui-datatables/-/mui-datatables-3.8.5.tgz#c9940edc8499b3bad52588ea20c350c2544b23ca"
+  integrity sha512-VS54Xkm5eXsPOUvzG3vXVjgSd2/nswwvhMK2D4PiHpV5MRJwfc6mdyuskh3s3jUi3NC8N+u7NsxX4pY14qaoKQ==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.12.1"
+    clsx "^1.1.1"
+    lodash.assignwith "^4.2.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.debounce "^4.0.8"
+    lodash.find "^4.6.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    lodash.isundefined "^3.0.1"
+    lodash.memoize "^4.1.2"
+    lodash.merge "^4.6.2"
+    prop-types "^15.7.2"
+    react-dnd "^11.1.3"
+    react-dnd-html5-backend "^11.1.3"
+    react-sortable-tree "^2.7.1"
+    react-to-print "^2.8.0"
 
 multicast-dns@^7.2.5:
   version "7.2.5"
@@ -12285,7 +12399,7 @@ prompts@^2.0.1, prompts@^2.4.0, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12407,7 +12521,7 @@ quickselect@^2.0.0:
   resolved "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz"
   integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
 
-raf@^3.4.1:
+raf@^3.2.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -12555,6 +12669,28 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+react-display-name@^0.2.0:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.5.tgz#304c7cbfb59ee40389d436e1a822c17fe27936c6"
+  integrity sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==
+
+react-dnd-html5-backend@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-11.1.3.tgz#2749f04f416ec230ea193f5c1fbea2de7dffb8f7"
+  integrity sha512-/1FjNlJbW/ivkUxlxQd7o3trA5DE33QiRZgxent3zKme8DwF4Nbw3OFVhTRFGaYhHFNL1rZt6Rdj1D78BjnNLw==
+  dependencies:
+    dnd-core "^11.1.3"
+
+react-dnd@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.3.tgz#f9844f5699ccc55dfc81462c2c19f726e670c1af"
+  integrity sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==
+  dependencies:
+    "@react-dnd/shallowequal" "^2.0.0"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    dnd-core "^11.1.3"
+    hoist-non-react-statics "^3.3.0"
+
 react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz"
@@ -12575,6 +12711,16 @@ react-docgen@^7.0.0:
     doctrine "^3.0.0"
     resolve "^1.22.1"
     strip-indent "^4.0.0"
+
+react-dom@^16.3.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
 
 react-dom@^18.2.0:
   version "18.2.0"
@@ -12627,6 +12773,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-openlayers@^0.3.0:
   version "0.3.0"
@@ -12760,6 +12911,19 @@ react-simple-maps@^3.0.0:
     d3-zoom "^2.0.0"
     topojson-client "^3.1.0"
 
+react-sortable-tree@^2.7.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-tree/-/react-sortable-tree-2.8.0.tgz#9901711778628d0546c045f845216480507c366a"
+  integrity sha512-gTjwxRNt7z0FC76KeNTnGqx1qUSlV3N78mMPRushBpSUXzZYhiFNsWHUIruyPnaAbw4SA7LgpItV7VieAuwDpw==
+  dependencies:
+    frontend-collective-react-dnd-scrollzone "^1.0.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.6.1"
+    react-dnd "^11.1.3"
+    react-dnd-html5-backend "^11.1.3"
+    react-lifecycles-compat "^3.0.4"
+    react-virtualized "^9.21.2"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz"
@@ -12768,6 +12932,11 @@ react-style-singleton@^2.2.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-to-print@^2.8.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.15.1.tgz#c9a6732cadf1118fc90d886b54a9388c419561b9"
+  integrity sha512-1foogIFbCpzAVxydkhBiDfMiFYhIMphiagDOfcG4X/EcQ+fBPqJ0rby9Wv/emzY1YLkIQy/rEgOrWQT+rBKhjw==
 
 react-transition-group@^4.4.0:
   version "4.4.5"
@@ -12783,6 +12952,27 @@ react-use-websocket@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.5.0.tgz"
   integrity sha512-oxYVLWM3Lv0InCfjW7hG/Hk0hkE0P1SiLd5/I3d5x0W4riAnDUkD4VEu7qNVAqxNjBF3nU7k0jLMOetLXpwfsA==
+
+react-virtualized@^9.21.2:
+  version "9.22.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
+  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
+
+react@^16.3.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"
@@ -13252,6 +13442,14 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.23.0:
   version "0.23.0"

--- a/server/migrations/0024_add_inventories_section_profile_page.up.sql
+++ b/server/migrations/0024_add_inventories_section_profile_page.up.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS community.inventory
     sku                 VARCHAR(100)                 ,
     quantity            INT                                   DEFAULT 1,
     boughtAt            VARCHAR(500)                 ,
-    location            INT                          ,
+    location            VARCHAR(500)                ,
     storage_location_id UUID                         REFERENCES storage_locations (id) ON UPDATE CASCADE ON DELETE CASCADE,
     created_at          TIMESTAMP WITH TIME ZONE     NOT NULL DEFAULT NOW(),
     created_by          UUID                         REFERENCES profiles (id) ON UPDATE CASCADE ON DELETE CASCADE,


### PR DESCRIPTION

The idea of this ticket was to add crud actions for inventories api but the task got a little overflowed with other various fixes and tech debt changes. Since the scope changes greatly, lets clear work upto here and take it forward from here. We can also use feature branch at this time to bring this code up to standard as it is also missing unit tests.

- add routes for api for crud on inventories api
- update dataLake to support proper inventory test data load
- cleanup comments on eventdb.go, notificationsdb.go, profiledb.go, userdb.go, inventorydb.go and notedb.go
- add ability to create new inventory item under profile section
- add handler to create new inventory item under profile section
- update swagger for note handler
- remove muiv4 table and use mui data tables to display values as this comes with default filter and couple of other features
- refactor and cleanup ui components
- add redux states for addInventory and its success and failure