### PR TITLE
Separate inventory and add dark mode for app

### DIFF
--- a/apilayer/handler/InventoriesHandler.go
+++ b/apilayer/handler/InventoriesHandler.go
@@ -79,7 +79,7 @@ func GetInventoryByID(rw http.ResponseWriter, r *http.Request, user string) {
 
 	resp, err := db.RetrieveSelectedInv(user, userID, invID)
 	if err != nil {
-		log.Printf("Unable to retrieve all existing inventories. error: +%v", err)
+		log.Printf("Unable to retrieve inventory with selected id. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(rw).Encode(err)
 		return
@@ -265,7 +265,7 @@ func UpdateSelectedInventory(rw http.ResponseWriter, r *http.Request, user strin
 		return
 	}
 
-	var inventory model.InventoryItemToUpdate
+	var inventory model.Inventory
 	if err := json.NewDecoder(r.Body).Decode(&inventory); err != nil {
 		log.Printf("Error decoding data. error: %+v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/InventoriesHandler_test.go
+++ b/apilayer/handler/InventoriesHandler_test.go
@@ -279,15 +279,10 @@ func Test_UpdateSelectedInventory(t *testing.T) {
 	// TODO: write another test that checks two different inserts into storage locations as
 	// this only tests updating the found name.
 
-	draftUpdateInventoryWithSameStorage := model.InventoryItemToUpdate{
-		Column: "name",
-		Value:  "Alexandro Kitty Litter",
-		ID:     selectedInventory.ID,
-		UserID: prevUser.ID.String(),
-	}
+	selectedInventory.Name = "Alexandro Kitty Litter"
 
 	// Marshal the draftEvent into JSON bytes
-	requestBody, err = json.Marshal(draftUpdateInventoryWithSameStorage)
+	requestBody, err = json.Marshal(selectedInventory)
 	if err != nil {
 		t.Errorf("failed to marshal JSON: %v", err)
 	}

--- a/apilayer/model/Inventory.go
+++ b/apilayer/model/Inventory.go
@@ -9,29 +9,30 @@ import (
 //
 // Inventory is the selected row for each inventory
 type Inventory struct {
-	ID                string    `json:"id"`
-	Name              string    `json:"name"`
-	Description       string    `json:"description"`
-	Price             float64   `json:"price"`
-	Status            string    `json:"status"`
-	Barcode           string    `json:"barcode"`
-	SKU               string    `json:"sku"`
-	Quantity          int       `json:"quantity"`
-	Location          string    `json:"location"`
-	StorageLocationID string    `json:"storage_location_id"`
-	IsReturnable      bool      `json:"is_returnable"`
-	ReturnLocation    string    `json:"return_location"`
-	MaxWeight         string    `json:"max_weight"`
-	MinWeight         string    `json:"min_weight"`
-	MaxHeight         string    `json:"max_height"`
-	MinHeight         string    `json:"min_height"`
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         string    `json:"created_by"`
-	CreatorName       string    `json:"creator_name"`
-	UpdatedAt         time.Time `json:"updated_at"`
-	UpdatedBy         string    `json:"updated_by"`
-	UpdaterName       string    `json:"updater_name"`
-	BoughtAt          string    `json:"bought_at"`
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	Price             float64    `json:"price"`
+	Status            string     `json:"status"`
+	Barcode           string     `json:"barcode"`
+	SKU               string     `json:"sku"`
+	Quantity          int        `json:"quantity"`
+	Location          string     `json:"location"`
+	StorageLocationID string     `json:"storage_location_id"`
+	IsReturnable      bool       `json:"is_returnable"`
+	ReturnLocation    string     `json:"return_location"`
+	ReturnDateTime    *time.Time `json:"return_datetime,omitempty"`
+	MaxWeight         string     `json:"max_weight"`
+	MinWeight         string     `json:"min_weight"`
+	MaxHeight         string     `json:"max_height"`
+	MinHeight         string     `json:"min_height"`
+	CreatedAt         time.Time  `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	CreatorName       string     `json:"creator_name"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	UpdatedBy         string     `json:"updated_by"`
+	UpdaterName       string     `json:"updater_name"`
+	BoughtAt          string     `json:"bought_at"`
 }
 
 // RawInventory ...

--- a/apilayer/model/Profile.go
+++ b/apilayer/model/Profile.go
@@ -20,6 +20,8 @@ type Profile struct {
 	PhoneNumber  string    `json:"phone_number"`
 	AboutMe      string    `json:"about_me"`
 	OnlineStatus bool      `json:"online_status"`
+	Appearance   bool      `json:"appearance"`
+	GridView     bool      `json:"grid_view"`
 	CreatedAt    time.Time `json:"created_at,omitempty"`
 	CreatedBy    string    `json:"created_by,omitempty"`
 	Creator      string    `json:"creator,omitempty"`

--- a/frontend/src/Store.js
+++ b/frontend/src/Store.js
@@ -9,6 +9,7 @@ import event from './Containers/Event/eventSlice';
 import profile from './features/Profile/profileSlice';
 import notes from './features/Notes/notesSlice';
 import categories from './features/Categories/categoriesSlice';
+import inventory from './features/InventoryList/inventorySlice';
 
 import { all } from 'redux-saga/effects'; // Import 'all' from redux-saga
 
@@ -18,6 +19,7 @@ import eventSaga from './Containers/Event/eventSaga';
 import profileSaga from './features/Profile/profileSaga';
 import notesSaga from './features/Notes/notesSaga';
 import categoriesSaga from './features/Categories/categoriesSaga';
+import inventorySaga from './features/InventoryList/inventorySaga';
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -30,6 +32,7 @@ function* rootSaga() {
     ...eventSaga.map((saga) => saga()),
     ...categoriesSaga.map((saga) => saga()),
     ...notesSaga.map((saga) => saga()),
+    ...inventorySaga.map((saga) => saga()),
   ]);
 }
 
@@ -40,6 +43,7 @@ export const store = configureStore({
     event,
     profile,
     categories,
+    inventory,
     notes,
   },
   middleware: [sagaMiddleware],

--- a/frontend/src/features/Home/homeSaga.js
+++ b/frontend/src/features/Home/homeSaga.js
@@ -15,7 +15,6 @@ export function* fetchAllEvents() {
   }
 }
 
-
 export function* createNewEvent(action) {
   try {
     const { draftEvent } = action.payload;

--- a/frontend/src/features/InventoryList/EditInventory.jsx
+++ b/frontend/src/features/InventoryList/EditInventory.jsx
@@ -12,15 +12,16 @@ import {
   createFilterOptions,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { BookmarkAddedRounded, CheckRounded, SwapHorizRounded } from '@mui/icons-material';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { BLANK_INVENTORY_FORM } from './constants';
 import HeaderWithButton from '../common/HeaderWithButton';
 import { useDispatch, useSelector } from 'react-redux';
-import { profileActions } from '../Profile/profileSlice';
 import { eventActions } from '../../Containers/Event/eventSlice';
+import { inventoryActions } from './inventorySlice';
+import { enqueueSnackbar } from 'notistack';
 
 const filter = createFilterOptions();
 dayjs.extend(relativeTime);
@@ -28,8 +29,9 @@ dayjs.extend(relativeTime);
 const EditInventory = () => {
   const { id } = useParams();
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
-  const { inventory, loading } = useSelector((state) => state.profile);
+  const { inventory, loading } = useSelector((state) => state.inventory);
   const { loading: storageLocationsLoading, storageLocations: options } = useSelector((state) => state.event);
 
   const [storageLocation, setStorageLocation] = useState({});
@@ -75,31 +77,32 @@ const EditInventory = () => {
     const isRequiredFieldsEmpty = requiredFormFields.some((el) => el.value.trim() === '');
 
     if (containsErr || isRequiredFieldsEmpty || storageLocation === null || Object.keys(storageLocation).length <= 0) {
+      enqueueSnackbar('Unable to update inventory details.', {
+        variant: 'error',
+      });
       return;
     }
 
-    //   const formattedData = Object.values(formData).reduce((acc, el) => {
-    //     if (el.value) {
-    //       acc[el.id] = el.value;
-    //     }
-    //     return acc;
-    //   }, {});
+    const formattedData = Object.values(formData).reduce((acc, el) => {
+      if (el.value) {
+        acc[el.id] = el.value;
+      }
+      return acc;
+    }, {});
 
-    //   const draftRequest = {
-    //     id: id, // bring id from the params
-    //     ...formattedData,
-    //     location: storageLocation.location,
-    //     updated_by: user.id,
-    //     updated_on: dayjs().toISOString(),
-    //   };
-
-    //   updateInventory.mutate(draftRequest);
-    setFormData({ ...BLANK_INVENTORY_FORM });
+    const draftRequest = {
+      id: id, // bring id from the params
+      ...formattedData,
+      location: storageLocation.location,
+      updated_on: dayjs().toISOString(),
+    };
+    dispatch(inventoryActions.updateInventory(draftRequest));
+    // navigate('/inventory/list');
   };
 
   useEffect(() => {
     if (id.length > 0) {
-      dispatch(profileActions.getInvByID(id));
+      dispatch(inventoryActions.getInvByID(id));
       dispatch(eventActions.getStorageLocations());
     }
   }, [id]);
@@ -127,9 +130,8 @@ const EditInventory = () => {
       draftInventoryForm.updated_by.value = inventory.updated_by || '';
       draftInventoryForm.updated_at.value = inventory.updated_at || '';
       draftInventoryForm.sharable_groups.value = inventory.sharable_groups || [];
-
       draftInventoryForm.creator_name = inventory.creator_name;
-      draftInventoryForm.updator_name = inventory.updator_name;
+      draftInventoryForm.updator_name = inventory.updater_name;
 
       setStorageLocation({ location: inventory.location });
       setFormData(draftInventoryForm);
@@ -368,59 +370,10 @@ const EditInventory = () => {
               />
             ))}
         </Stack>
-
-        <Divider>
-          <Typography variant="caption">User information</Typography>
-        </Divider>
-
-        <Stack direction="row" spacing={2}>
-          {Object.values(formData)
-            .filter((v, index) => index >= 16 && index < 18)
-            .map((v) => (
-              <TextField
-                key={v.id}
-                id={v.id}
-                label={v.id === 'created_on' && 'Created'}
-                value={
-                  'created_on' === v.id
-                    ? dayjs(v.value).fromNow()
-                    : `Created by ${formData?.creator_name?.username || 'Anonymous'}`
-                }
-                disabled
-                fullWidth
-                size="small"
-                variant="standard"
-                onChange={handleInputChange}
-              />
-            ))}
-        </Stack>
-
-        <Stack direction="row" spacing={2}>
-          {Object.values(formData)
-            .filter((v, index) => index >= 18 && index < 20)
-            .map((v) => (
-              <TextField
-                key={v.id}
-                id={v.id}
-                label={v.id === 'updated_on' && 'Last updated around'}
-                value={
-                  v.id === 'updated_on'
-                    ? dayjs(v.value).fromNow()
-                    : `Last updated by ${formData?.updator_name?.username || 'Anonymous'}`
-                }
-                disabled
-                fullWidth
-                size="small"
-                variant="standard"
-                onChange={handleInputChange}
-              />
-            ))}
-        </Stack>
       </Stack>
-
       <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
         <Box sx={{ flex: '1 1 auto' }} />
-        <Button startIcon={<CheckRounded />} onClick={handleSubmit}>
+        <Button startIcon={<CheckRounded fontSize="small" />} onClick={handleSubmit}>
           Submit
         </Button>
       </Box>

--- a/frontend/src/features/InventoryList/InventoryList.jsx
+++ b/frontend/src/features/InventoryList/InventoryList.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import InventoryListDetails from './InventoryListDetails';
 import { useDispatch } from 'react-redux';
-import { profileActions } from '../Profile/profileSlice';
+import { inventoryActions } from './inventorySlice';
 import { RetrieveClientLocation } from '../common/utils';
 
 export default function InventoryList() {
@@ -11,7 +11,7 @@ export default function InventoryList() {
   console.debug(location); // todo remove this later
 
   useEffect(() => {
-    dispatch(profileActions.getAllInventoriesForUser());
+    dispatch(inventoryActions.getAllInventoriesForUser());
     const clientLocationCoordinates = RetrieveClientLocation();
     setLocation(clientLocationCoordinates);
   }, []);

--- a/frontend/src/features/InventoryList/InventoryListDetails.jsx
+++ b/frontend/src/features/InventoryList/InventoryListDetails.jsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { Autocomplete, Dialog, DialogTitle, IconButton, Slide, Stack, TextField, Typography } from '@mui/material';
+import {
+  Autocomplete,
+  Dialog,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  Slide,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
 import {
   CheckRounded,
   CircleRounded,
@@ -35,7 +47,7 @@ const MODAL_STATE = {
 
 const InventoryListDetails = ({ hideActionMenu = false }) => {
   const navigate = useNavigate();
-  const { loading, inventories } = useSelector((state) => state.profile);
+  const { loading, inventories } = useSelector((state) => state.inventory);
 
   const [options, setOptions] = useState([]);
   const [inputColumn, setInputColumn] = useState('');
@@ -48,7 +60,6 @@ const InventoryListDetails = ({ hideActionMenu = false }) => {
   const [idToDelete, setIdToDelete] = useState(-1);
   const [modalState, setModalState] = useState(MODAL_STATE.NONE);
 
-  const handleViewMode = (value) => setGridMode(value);
   const handleCloseModal = () => setModalState(MODAL_STATE.NONE);
   // const handleAddCategory = () => setModalState(MODAL_STATE.ASSIGN_CATEGORY);
   // const handleAddInventory = () => setModalState(MODAL_STATE.ASSIGN_MAINTENANCE_PLAN);
@@ -195,15 +206,27 @@ const InventoryListDetails = ({ hideActionMenu = false }) => {
 
   return (
     <Stack flexGrow="1">
-      <HeaderWithButton
-        title="Assets"
-        primaryButtonTextLabel="Grid"
-        primaryStartIcon={<GridViewRounded />}
-        handleClickPrimaryButton={() => handleViewMode(true)}
-        secondaryButtonTextLabel="List"
-        secondaryStartIcon={<ViewListRounded />}
-        handleClickSecondaryButton={() => handleViewMode(false)}
-      />
+      <Stack direction="row" justifyContent="space-between">
+        <HeaderWithButton title="Assets" />
+        <FormGroup>
+          <FormControlLabel
+            control={<Switch defaultChecked size="small" />}
+            sx={{
+              alignItems: 'unset',
+            }}
+            label={
+              gridMode ? (
+                <GridViewRounded color="primary" fontSize="small" />
+              ) : (
+                <ViewListRounded color="primary" fontSize="small" />
+              )
+            }
+            labelPlacement="end"
+            onClick={() => setGridMode(!gridMode)}
+          />
+        </FormGroup>
+      </Stack>
+
       <Autocomplete
         sx={{ maxWidth: '20rem', mb: 1 }}
         id="inventory-items-autocomplete"

--- a/frontend/src/features/InventoryList/constants.jsx
+++ b/frontend/src/features/InventoryList/constants.jsx
@@ -322,19 +322,6 @@ export const BLANK_INVENTORY_FORM = {
       },
     ],
   },
-  return_datetime: {
-    id: 'return_datetime',
-    value: '',
-    type: 'datetime',
-    isRequired: false,
-    errorMsg: '',
-    validators: [
-      {
-        validate: (value) => value < new Date().toISOString(),
-        message: 'Return datetime cannot be an eariler date or time',
-      },
-    ],
-  },
   max_weight: {
     id: 'max_weight',
     label: 'Max weight in kg',

--- a/frontend/src/features/InventoryList/inventorySaga.js
+++ b/frontend/src/features/InventoryList/inventorySaga.js
@@ -1,0 +1,102 @@
+import { takeLatest, put, call } from 'redux-saga/effects';
+import { REACT_APP_LOCALHOST_URL } from '../../util/Common';
+import { inventoryActions } from './inventorySlice';
+import instance from '../../util/Instances';
+
+const BASEURL = `${REACT_APP_LOCALHOST_URL}/api/v1/profile`;
+
+export function* fetchAllInventoriesForUser() {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.get, `${BASEURL}/${USER_ID}/inventories`);
+    yield put(inventoryActions.getAllInventoriesForUserSuccess(response.data || {}));
+  } catch (e) {
+    yield put(inventoryActions.getAllInventoriesForUserFailure(e));
+  }
+}
+
+export function* fetchInvByID({ payload }) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.get, `${BASEURL}/${USER_ID}/inventories/${payload}`);
+    yield put(inventoryActions.getInvByIDSuccess(response.data || []));
+  } catch (e) {
+    yield put(inventoryActions.getInvByIDFailure(e));
+  }
+}
+
+export function* fetchAddNewInventory(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories`, { ...action.payload });
+    yield put(inventoryActions.addInventorySuccess(response.data));
+  } catch (e) {
+    yield put(inventoryActions.addInventoryFailure(e));
+  }
+}
+
+export function* fetchAddBulkInventory(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories/bulk`, { ...action.payload });
+    yield put(inventoryActions.addBulkInventorySuccess(response.data));
+  } catch (e) {
+    yield put(inventoryActions.addBulkInventoryFailure(e));
+  }
+}
+
+export function* fetchUpdateExistingInventoryDetails(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.put, `${BASEURL}/${USER_ID}/inventories`, { ...action.payload });
+    yield put(inventoryActions.updateInventorySuccess(response.data));
+  } catch (e) {
+    yield put(inventoryActions.updateInventoryFailure(e));
+  }
+}
+
+export function* fetchRemoveInventoryRows(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories/prune`, { ...action.payload });
+    yield put(inventoryActions.removeInventoryRowsSuccess(response.data));
+  } catch (e) {
+    yield put(inventoryActions.removeInventoryRowsFailure(e));
+  }
+}
+
+/********************************
+ * WATCHER FUNCTIONS BELOW HERE
+ ********************************/
+
+export function* watchFetchAllInventoriesForUser() {
+  yield takeLatest(`inventory/getAllInventoriesForUser`, fetchAllInventoriesForUser);
+}
+
+export function* watchFetchInvByID() {
+  yield takeLatest(`inventory/getInvByID`, fetchInvByID);
+}
+
+export function* watchFetchAddNewInventory() {
+  yield takeLatest(`inventory/addInventory`, fetchAddNewInventory);
+}
+
+export function* watchFetchAddBulkInventory() {
+  yield takeLatest(`inventory/addBulkInventory`, fetchAddBulkInventory);
+}
+
+export function* watchUpdateExistingInventoryDetails() {
+  yield takeLatest(`inventory/updateInventory`, fetchUpdateExistingInventoryDetails);
+}
+
+export function* watchFetchRemoveInventoryRows() {
+  yield takeLatest(`inventory/removeInventoryRows`, fetchRemoveInventoryRows);
+}
+
+export default [
+  watchFetchInvByID,
+  watchFetchAddBulkInventory,
+  watchFetchRemoveInventoryRows,
+  watchFetchAllInventoriesForUser,
+  watchUpdateExistingInventoryDetails,
+];

--- a/frontend/src/features/InventoryList/inventorySlice.js
+++ b/frontend/src/features/InventoryList/inventorySlice.js
@@ -1,0 +1,113 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  loading: false,
+  error: '',
+  inventory: {},
+  inventories: [],
+};
+
+const inventorySlice = createSlice({
+  name: 'inventory',
+  initialState,
+  reducers: {
+    getAllInventoriesForUser: (state) => {
+      state.loading = true;
+      state.error = '';
+      state.inventories = [];
+    },
+    getAllInventoriesForUserSuccess: (state, action) => {
+      state.inventories = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    getAllInventoriesForUserFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
+    getInvByID: (state) => {
+      state.loading = true;
+      state.error = '';
+      state.inventory = {};
+    },
+    getInvByIDSuccess: (state, action) => {
+      state.inventory = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    getInvByIDFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventory = {};
+    },
+    addInventory: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    addInventorySuccess: (state, action) => {
+      const updatedValues = action.payload;
+      state.loading = false;
+      state.error = '';
+      state.inventories = [updatedValues, ...state.inventories];
+    },
+    addInventoryFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
+    addBulkInventory: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    addBulkInventorySuccess: (state, action) => {
+      const updatedValues = action.payload;
+      state.loading = false;
+      state.error = '';
+      state.inventories = [...updatedValues, ...state.inventories];
+    },
+    addBulkInventoryFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
+    updateInventory: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    updateInventorySuccess: (state, action) => {
+      const updatedItem = action.payload;
+      const filteredInventoriesList = state.inventories.filter((v) => v.id !== updatedItem.id);
+      state.loading = false;
+      state.error = '';
+      state.inventory = { ...updatedItem };
+      state.inventories = [updatedItem, ...filteredInventoriesList];
+    },
+    updateInventoryFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
+    removeInventoryRows: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    removeInventoryRowsSuccess: (state, action) => {
+      const updatedInventoriesID = action.payload;
+      const filteredInventories = state.inventories.filter((inventory) => {
+        return !updatedInventoriesID.includes(inventory.id);
+      });
+      state.loading = false;
+      state.error = '';
+      state.inventories = [...filteredInventories];
+    },
+    removeInventoryRowsFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.inventories = [];
+    },
+  },
+});
+
+export const { actions: inventoryActions } = inventorySlice;
+export default inventorySlice.reducer;

--- a/frontend/src/features/Layout/Layout.jsx
+++ b/frontend/src/features/Layout/Layout.jsx
@@ -5,21 +5,24 @@ import {
   CircularProgress,
   CssBaseline,
   IconButton,
+  Skeleton,
   Stack,
   ThemeProvider,
   Toolbar,
   Tooltip,
   Typography,
 } from '@mui/material';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import MenuActionBar from './MenuActionBar';
-import { lightTheme } from '../../util/Theme';
+import { darkTheme, lightTheme } from '../../util/Theme';
 import { LogoutRounded } from '@mui/icons-material';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { authActions } from '../../Containers/Auth/authSlice';
+import { profileActions } from '../Profile/profileSlice';
 
 const Layout = () => {
   const dispatch = useDispatch();
+  const { loading, profileDetails } = useSelector((state) => state.profile);
 
   const handleLogout = () => {
     dispatch(authActions.getLogout());
@@ -27,8 +30,16 @@ const Layout = () => {
     window.location.href = '/';
   };
 
+  useEffect(() => {
+    dispatch(profileActions.getProfileDetails());
+  }, []);
+
+  if (loading) {
+    return <Skeleton width="100%" height="100%" />;
+  }
+
   return (
-    <ThemeProvider theme={lightTheme}>
+    <ThemeProvider theme={profileDetails.appearance ? darkTheme : lightTheme}>
       <CssBaseline />
       <Suspense
         fallback={

--- a/frontend/src/features/Notes/NotesDetails.jsx
+++ b/frontend/src/features/Notes/NotesDetails.jsx
@@ -83,6 +83,7 @@ const NotesDetails = ({ notes, loading, setEditMode, setSelectedNoteID }) => {
                     p: 1,
                     borderRadius: '0.2rem',
                     borderLeft: '0.175rem solid',
+                    backgroundColor: 'background.default',
                     borderColor: note.color ? `${note.color}` : 'primary.main',
                   }}
                 >

--- a/frontend/src/features/Profile/Appearance/Appearance.jsx
+++ b/frontend/src/features/Profile/Appearance/Appearance.jsx
@@ -1,34 +1,35 @@
 import { Box, Button, Checkbox, Divider, FormControlLabel, Skeleton, Stack, Typography } from '@mui/material';
 import { DarkModeRounded, GridViewRounded } from '@mui/icons-material';
 import { useEffect, useState } from 'react';
-// import dayjs from 'dayjs';
+import { useDispatch, useSelector } from 'react-redux';
+import { profileActions } from '../profileSlice';
+import dayjs from 'dayjs';
 
 const AppearanceSettings = () => {
-  const data = {};
-  const isLoading = false;
+  const dispatch = useDispatch();
+  const { loading, profileDetails } = useSelector((state) => state.profile);
+
   const [displayMode, setDisplayMode] = useState(false);
   const [inventoryLayout, setInventoryLayout] = useState(false); // false is list view
 
   const handleSubmit = () => {
-    // const draftFormattedData = {
-    //   // id: user?.id,
-    //   display_mode: displayMode,
-    //   inventory_layout: inventoryLayout,
-    //   // updated_by: user?.id,
-    //   updated_on: dayjs(),
-    // };
-    // upsertProfileConfigDetailsMutation.mutate(draftFormattedData);
-    // navigate('/');
+    const draftData = {
+      ...profileDetails,
+      appearance: displayMode,
+      grid_view: inventoryLayout,
+      updated_at: dayjs().toISOString(),
+    };
+    dispatch(profileActions.updateProfileDetails({ draftData }));
   };
 
   useEffect(() => {
-    if (!isLoading) {
-      setDisplayMode(data?.display_mode);
-      setInventoryLayout(data?.inventory_layout);
+    if (!loading) {
+      setDisplayMode(profileDetails.appearance ?? false);
+      setInventoryLayout(profileDetails.grid_view ?? false);
     }
-  }, [isLoading]);
+  }, [loading]);
 
-  if (isLoading) {
+  if (loading) {
     return <Skeleton variant="rounded" animation="wave" height="100%" width="100%" />;
   }
   return (

--- a/frontend/src/features/Profile/ProfileContent.jsx
+++ b/frontend/src/features/Profile/ProfileContent.jsx
@@ -16,7 +16,7 @@ const ProfileContent = () => {
 
   const submit = (ev) => {
     ev.preventDefault();
-    const formattedData = Object.entries(formData).reduce((acc, [key, valueObj]) => {
+    const draftData = Object.entries(formData).reduce((acc, [key, valueObj]) => {
       if (['created_on', 'updated_on'].includes(key)) {
         acc[key] = valueObj;
       } else {
@@ -24,8 +24,8 @@ const ProfileContent = () => {
       }
       return acc;
     }, {});
-    formattedData['updated_on'] = dayjs();
-    dispatch(profileActions.updateProfileDetails({ formattedData }));
+    draftData['updated_on'] = dayjs();
+    dispatch(profileActions.updateProfileDetails({ draftData }));
   };
 
   const handleChange = (ev) => {
@@ -45,10 +45,6 @@ const ProfileContent = () => {
     };
     setFormData(updatedFormData);
   };
-
-  useEffect(() => {
-    dispatch(profileActions.getProfileDetails());
-  }, []);
 
   useEffect(() => {
     if (!loading) {

--- a/frontend/src/features/Profile/profileSaga.js
+++ b/frontend/src/features/Profile/profileSaga.js
@@ -27,14 +27,11 @@ export function* fetchExistingUserDetails() {
 export function* updateExistingUserDetails(action) {
   try {
     const USER_ID = localStorage.getItem('userID');
-    const { formattedData } = action.payload;
+    const { draftData } = action.payload;
     const response = yield call(instance.put, `${BASEURL}/${USER_ID}`, {
       id: USER_ID,
-      username: formattedData.username,
-      full_name: formattedData.full_name,
-      email_address: formattedData.email_address,
-      phone_number: formattedData.phone_number,
-      about_me: formattedData.about_me,
+      ...draftData,
+      updated_by: USER_ID,
     });
     yield put(profileActions.getProfileDetailsSuccess(response.data));
   } catch (e) {
@@ -51,70 +48,6 @@ export function* fetchUpdateProfileImage(action) {
     yield put(profileActions.updateProfileImageSuccess(response.data));
   } catch (e) {
     yield put(profileActions.updateProfileImageFailure(e));
-  }
-}
-
-/**
- * Inventories related api calls
- */
-
-export function* fetchAllInventoriesForUser() {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.get, `${BASEURL}/${USER_ID}/inventories`);
-    yield put(profileActions.getAllInventoriesForUserSuccess(response.data || {}));
-  } catch (e) {
-    yield put(profileActions.getAllInventoriesForUserFailure(e));
-  }
-}
-
-export function* fetchInvByID({ payload }) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.get, `${BASEURL}/${USER_ID}/inventories/${payload}`);
-    yield put(profileActions.getInvByIDSuccess(response.data || []));
-  } catch (e) {
-    yield put(profileActions.getInvByIDFailure(e));
-  }
-}
-
-export function* fetchAddNewInventory(action) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories`, { ...action.payload });
-    yield put(profileActions.addInventorySuccess(response.data));
-  } catch (e) {
-    yield put(profileActions.addInventoryFailure(e));
-  }
-}
-
-export function* fetchAddBulkInventory(action) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories/bulk`, { ...action.payload });
-    yield put(profileActions.addBulkInventorySuccess(response.data));
-  } catch (e) {
-    yield put(profileActions.addBulkInventoryFailure(e));
-  }
-}
-
-export function* fetchUpdateExistingInventoryDetails(action) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.put, `${BASEURL}/${USER_ID}/inventories`, { ...action.payload });
-    yield put(profileActions.updateInventorySuccess(response.data));
-  } catch (e) {
-    yield put(profileActions.updateInventoryFailure(e));
-  }
-}
-
-export function* fetchRemoveInventoryRows(action) {
-  try {
-    const USER_ID = localStorage.getItem('userID');
-    const response = yield call(instance.post, `${BASEURL}/${USER_ID}/inventories/prune`, { ...action.payload });
-    yield put(profileActions.removeInventoryRowsSuccess(response.data));
-  } catch (e) {
-    yield put(profileActions.removeInventoryRowsFailure(e));
   }
 }
 
@@ -138,38 +71,9 @@ export function* watchFetchUpdateProfileImage() {
   yield takeEvery(`profile/updateProfileImage`, fetchUpdateProfileImage);
 }
 
-export function* watchFetchAllInventoriesForUser() {
-  yield takeLatest(`profile/getAllInventoriesForUser`, fetchAllInventoriesForUser);
-}
-
-export function* watchFetchInvByID() {
-  yield takeLatest(`profile/getInvByID`, fetchInvByID);
-}
-
-export function* watchFetchAddNewInventory() {
-  yield takeLatest(`profile/addInventory`, fetchAddNewInventory);
-}
-
-export function* watchFetchAddBulkInventory() {
-  yield takeLatest(`profile/addBulkInventory`, fetchAddBulkInventory);
-}
-
-export function* watchUpdateExistingInventoryDetails() {
-  yield takeLatest(`profile/updateInventory`, fetchUpdateExistingInventoryDetails);
-}
-
-export function* watchFetchRemoveInventoryRows() {
-  yield takeLatest(`profile/removeInventoryRows`, fetchRemoveInventoryRows);
-}
-
 export default [
   watchFetchProfileList,
-  watchFetchInvByID,
   watchFetchExistingUserDetails,
-  watchFetchAddBulkInventory,
-  watchFetchRemoveInventoryRows,
-  watchFetchAllInventoriesForUser,
   watchUpdateExistingUserDetails,
   watchFetchUpdateProfileImage,
-  watchUpdateExistingInventoryDetails,
 ];

--- a/frontend/src/features/Profile/profileSlice.js
+++ b/frontend/src/features/Profile/profileSlice.js
@@ -4,8 +4,6 @@ const initialState = {
   loading: false,
   error: '',
   profiles: [],
-  inventory: {},
-  inventories: [],
   profileDetails: {},
 };
 
@@ -69,100 +67,6 @@ const profileSlice = createSlice({
     updateProfileImageFailure: (state) => {
       state.loading = false;
       state.error = '';
-    },
-    getAllInventoriesForUser: (state) => {
-      state.loading = true;
-      state.error = '';
-      state.inventories = [];
-    },
-    getAllInventoriesForUserSuccess: (state, action) => {
-      state.inventories = action.payload;
-      state.loading = false;
-      state.error = '';
-    },
-    getAllInventoriesForUserFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventories = [];
-    },
-    getInvByID: (state) => {
-      state.loading = true;
-      state.error = '';
-      state.inventory = {};
-    },
-    getInvByIDSuccess: (state, action) => {
-      state.inventory = action.payload;
-      state.loading = false;
-      state.error = '';
-    },
-    getInvByIDFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventory = {};
-    },
-    addInventory: (state) => {
-      state.loading = true;
-      state.error = '';
-    },
-    addInventorySuccess: (state, action) => {
-      const updatedValues = action.payload;
-      state.loading = false;
-      state.error = '';
-      state.inventories = [updatedValues, ...state.inventories];
-    },
-    addInventoryFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventories = [];
-    },
-    addBulkInventory: (state) => {
-      state.loading = true;
-      state.error = '';
-    },
-    addBulkInventorySuccess: (state, action) => {
-      const updatedValues = action.payload;
-      state.loading = false;
-      state.error = '';
-      state.inventories = [...updatedValues, ...state.inventories];
-    },
-    addBulkInventoryFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventories = [];
-    },
-    updateInventory: (state) => {
-      state.loading = true;
-      state.error = '';
-    },
-    updateInventorySuccess: (state, action) => {
-      const updatedItem = action.payload;
-      const filteredInventoriesList = state.inventories.filter((v) => v.id !== updatedItem.id);
-      state.loading = false;
-      state.error = '';
-      state.inventories = [updatedItem, ...filteredInventoriesList];
-    },
-    updateInventoryFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventories = [];
-    },
-    removeInventoryRows: (state) => {
-      state.loading = true;
-      state.error = '';
-    },
-    removeInventoryRowsSuccess: (state, action) => {
-      const updatedInventoriesID = action.payload;
-      const filteredInventories = state.inventories.filter((inventory) => {
-        return !updatedInventoriesID.includes(inventory.id);
-      });
-      state.loading = false;
-      state.error = '';
-      state.inventories = [...filteredInventories];
-    },
-    removeInventoryRowsFailure: (state) => {
-      state.loading = false;
-      state.error = '';
-      state.inventories = [];
     },
   },
 });

--- a/frontend/src/features/common/utils.jsx
+++ b/frontend/src/features/common/utils.jsx
@@ -11,10 +11,14 @@ import CryptoJS from 'crypto-js';
 export const RetrieveClientLocation = () => {
   const ciphertext = localStorage.getItem('client_location');
   if (ciphertext) {
-    const userID = localStorage.getItem('userID');
-    const bytes = CryptoJS.AES.decrypt(ciphertext, userID);
-    const decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
-    return decryptedData;
+    try {
+      const userID = localStorage.getItem('userID');
+      const bytes = CryptoJS.AES.decrypt(ciphertext, userID);
+      const decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+      return decryptedData || {};
+    } catch (e) {
+      // eat exception
+    }
   }
   return null;
 };

--- a/server/migrations/0006_create_profiles_table_community.up.sql
+++ b/server/migrations/0006_create_profiles_table_community.up.sql
@@ -1,4 +1,3 @@
-
 -- File: 0006_create_profiles_table_community.up.sql
 -- Description: Create the users profile table and grant permissions on the table.
 
@@ -10,11 +9,12 @@ CREATE TABLE profiles
     updated_at    TIMESTAMP WITH TIME ZONE                                       NOT NULL DEFAULT NOW(),
     username      VARCHAR(50)                                                    NULL,
     full_name     VARCHAR(200)                                                   NULL,
-    avatar_url    BYTEA                                                   NULL,
+    avatar_url    BYTEA                                                          NULL,
     email_address VARCHAR(250)                                                   NOT NULL UNIQUE,
     phone_number  VARCHAR(250)                                                   NULL,
-    goal          VARCHAR(250)                                                   NULL,
     about_me      VARCHAR(250)                                                   NULL,
+    appearance    BOOLEAN                                                                 DEFAULT FALSE,
+    grid_view     BOOLEAN                                                                 DEFAULT FALSE,
     onlineStatus  BOOLEAN                                                                 DEFAULT FALSE,
     role          VARCHAR(10)                                                             DEFAULT 'USER'
         CONSTRAINT username_length CHECK (char_length(username) >= 3)

--- a/server/migrations/0012_create_inventories_table.up.sql
+++ b/server/migrations/0012_create_inventories_table.up.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS community.inventory
     storage_location_id                                                                                             UUID REFERENCES storage_locations (id) ON UPDATE CASCADE ON DELETE CASCADE,
     is_returnable         BOOLEAN                  NOT NULL                                         DEFAULT false,
     return_location       VARCHAR(200)             NULL,
+    return_datetime       TIMESTAMP WITH TIME ZONE NULL,
     max_weight            VARCHAR(10)              NULL,
     min_weight            VARCHAR(10)              NULL,
     max_height            VARCHAR(10)              NULL,

--- a/setup/devscript/test_data.sql
+++ b/setup/devscript/test_data.sql
@@ -71,7 +71,7 @@ VALUES ('4 pounds of kitty litter',
         (SELECT id FROM community.profiles p LIMIT 1),
         ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
 
-
+-- return with a null datetime --
 INSERT INTO community.inventory (name, description, price, status, barcode, sku, quantity, bought_at, location,
                                  storage_location_id, is_returnable, return_location, max_weight, min_weight,
                                  max_height, min_height, created_by, updated_by, sharable_groups)


### PR DESCRIPTION
- add application support for dark mode
- seperate inventory to its own saga and slice
- support for dark mode throughout the app. this can be set currently from
the profile section we should move it to the main app bar so users have easy access.
- unit test fix for profile db
- add fixes for lint issue
- add fix for editing an inventory in ui layer. updated slice so that both inventories
and inventory in the redux store can get populated as we need the values overall.
- support for editing inventory in db layer. currently all api calls are required
to put everything back. we still need to support updating one item so keeping some of
the existing api for later use.
- address date and time picker in edit inventory
- add ability to navigate to inventory page after updating inventory
- fix unit tests
