### PR TITLE
212 - Address ability to view Maintenance Items

### DIFF
--- a/apilayer/db/MaintenancePlandb.go
+++ b/apilayer/db/MaintenancePlandb.go
@@ -177,6 +177,7 @@ func RetrieveAllMaintenancePlanItems(user string, userID string, maintenancePlan
 
 	rows, err := db.Query(sqlStr, userID, maintenancePlanID, limit)
 	if err != nil {
+		log.Printf("unable to retrieve maintenance items. error: %+v", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -187,6 +188,7 @@ func RetrieveAllMaintenancePlanItems(user string, userID string, maintenancePlan
 	for rows.Next() {
 		var ec model.MaintenanceItemResponse
 		if err := rows.Scan(&ec.ID, &ec.MaintenancePlanID, &ec.ItemID, &ec.Name, &ec.Description, &ec.Price, &ec.Quantity, &ec.Location, &ec.CreatedBy, &ec.Creator, &ec.CreatedAt, &ec.UpdatedBy, &ec.Updator, &ec.UpdatedAt, &sharableGroups); err != nil {
+			log.Printf("unable to retrieve maintenance items. error: %+v", err)
 			return nil, err
 		}
 		ec.SharableGroups = sharableGroups
@@ -194,6 +196,7 @@ func RetrieveAllMaintenancePlanItems(user string, userID string, maintenancePlan
 	}
 
 	if err := rows.Err(); err != nil {
+		log.Printf("unable to retrieve maintenance items. error: %+v", err)
 		return nil, err
 	}
 
@@ -448,7 +451,7 @@ func AddAssetToMaintenancePlan(user string, userID string, maintenancePlanID str
 
 	sqlStr = `SELECT 
 		mi.id,
-		mi.category_id,
+		mi.maintenance_plan_id,
 		mi.item_id,
 		i.name,
 		i.description,
@@ -462,15 +465,16 @@ func AddAssetToMaintenancePlan(user string, userID string, maintenancePlanID str
 		COALESCE(up.username, up.full_name, cp.email_address, 'Anonymous') as updator,
 		mi.updated_at,
 		mi.sharable_groups
-	FROM community.category_item mi
+	FROM community.maintenance_item mi
 	LEFT JOIN community.inventory i ON mi.item_id = i.id
 	LEFT JOIN community.profiles cp ON mi.created_by = cp.id
 	LEFT JOIN community.profiles up ON mi.updated_by = up.id
-	WHERE $1::UUID = ANY(mi.sharable_groups) AND mi.category_id = $2
+	WHERE $1::UUID = ANY(mi.sharable_groups) AND mi.maintenance_plan_id = $2
 	ORDER BY mi.updated_at DESC;`
 
 	rows, err := db.Query(sqlStr, userID, maintenancePlanID)
 	if err != nil {
+		log.Printf("unable to retrieve maintenance items. error: %+v", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -481,6 +485,7 @@ func AddAssetToMaintenancePlan(user string, userID string, maintenancePlanID str
 	for rows.Next() {
 		var ec model.MaintenanceItemResponse
 		if err := rows.Scan(&ec.ID, &ec.MaintenancePlanID, &ec.ItemID, &ec.Name, &ec.Description, &ec.Price, &ec.Quantity, &ec.Location, &ec.CreatedBy, &ec.Creator, &ec.CreatedAt, &ec.UpdatedBy, &ec.Updator, &ec.UpdatedAt, &sharableGroups); err != nil {
+			log.Printf("unable to retrieve maintenance items. error: %+v", err)
 			return nil, err
 		}
 		ec.SharableGroups = sharableGroups
@@ -488,6 +493,7 @@ func AddAssetToMaintenancePlan(user string, userID string, maintenancePlanID str
 	}
 
 	if err := rows.Err(); err != nil {
+		log.Printf("unable to retrieve maintenance items. error: %+v", err)
 		return nil, err
 	}
 

--- a/frontend/src/features/Maintenance/MaintenanceItem.jsx
+++ b/frontend/src/features/Maintenance/MaintenanceItem.jsx
@@ -83,7 +83,7 @@ export default function MaintenanceItem() {
     }
   }, [id]);
 
-  if (inventoriesLoading || loading) {
+  if (loading) {
     return <Skeleton height="20rem" />;
   }
 

--- a/frontend/src/features/Maintenance/maintenanceSlice.js
+++ b/frontend/src/features/Maintenance/maintenanceSlice.js
@@ -121,7 +121,7 @@ const maintenancePlanSlice = createSlice({
       state.error = '';
     },
     addItemsInPlanSuccess: (state, action) => {
-      state.itemsInCategory = [...action.payload];
+      state.itemsInMaintenancePlan = [...action.payload];
       state.loading = false;
       state.error = '';
     },

--- a/frontend/src/util/Chart/BarChart.jsx
+++ b/frontend/src/util/Chart/BarChart.jsx
@@ -1,13 +1,7 @@
 import 'chart.js/auto';
-import { Doughnut } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 
-const DoughnutChart = ({
-  data,
-  legendLabel,
-  backgroundColor,
-  borderColor,
-  height = '25rem',
-}) => {
+const BarChart = ({ data, legendLabel, backgroundColor, borderColor, height = '25rem' }) => {
   let chartData = {
     labels: data.map((d) => d.label),
     datasets: [
@@ -30,13 +24,16 @@ const DoughnutChart = ({
       },
       tooltip: {
         callbacks: {
-          label: function(context) {
+          label: function (context) {
             let label = context.label || '';
             if (label) {
               label += ': ';
             }
             if (context.parsed !== null) {
-              label += `${context.parsed} (${((context.parsed / data.reduce((sum, item) => sum + item.count, 0)) * 100).toFixed(2)}%)`;
+              label += `${context.parsed} (${(
+                (context.parsed / data.reduce((sum, item) => sum + item.count, 0)) *
+                100
+              ).toFixed(2)}%)`;
             }
             return label;
           },
@@ -47,9 +44,9 @@ const DoughnutChart = ({
 
   return (
     <div style={{ width: '100%', height: height }}>
-      <Doughnut data={chartData} options={options} />
+      <Bar data={chartData} options={options} />
     </div>
   );
 };
 
-export default DoughnutChart;
+export default BarChart;


### PR DESCRIPTION
- adds support to display maintenance items after adding them.
- updates the redux actions to use maintenance values instead of category values
- update loading state to re-render only when maintenance plans is rendering
- update BarChart to display Bar graphs instead of Doughnuts.

closes #212

## Screenshots / Visuals
![image](https://github.com/user-attachments/assets/343517b9-38a9-4f5f-a210-d15109d8cc4f)

