### PR TITLE
200 - Update asset summary details

### DIFF
--- a/apilayer/db/AssetSummary.go
+++ b/apilayer/db/AssetSummary.go
@@ -1,105 +1,142 @@
 package db
 
 import (
-	"database/sql"
+	"log"
 
 	"github.com/lib/pq"
 	"github.com/mohit2530/communityCare/model"
 )
 
-// RetrieveAllAssetSummary ...
-func RetrieveAllAssetSummary(user string, userID string) ([]model.AssetSummary, error) {
+// RetrieveAssetsAndSummary...
+func RetrieveAssetsAndSummary(user string, userID string) (model.AssetsAndSummaryResponse, error) {
 	db, err := SetupDB(user)
 	if err != nil {
-		return nil, err
+		log.Printf("unable to setup db. error: %+v", err)
+		return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
 	}
 	defer db.Close()
 
-	sqlStr := `SELECT id, name, type, returnTime, price, category_id, plan_id, created_at, updated_at, sharable_groups FROM (
-SELECT
-    c.id,
-    c.name,
-    'C' as type,
-    NULL::timestamp with time zone as returnTime,
-	0 as price,
-	ci.category_id as category_id,
-	NULL as plan_id,
-    c.created_at,
-    c.updated_at,
-	c.sharable_groups
-FROM community.category c
-LEFT JOIN community.category_item ci on c.id = ci.id
-UNION
-SELECT
-    mp.id,
-    mp.name,
-    'M' as type,
-    NULL::timestamp with time zone as returnTime,
-	0 as price,
-	NULL as category_id,
-	mi.maintenance_plan_id as plan_id,
-    mp.created_at,
-    mp.updated_at,
-	mp.sharable_groups
-FROM community.maintenance_plan mp
-LEFT JOIN community.maintenance_item mi on mp.id = mi.id
-UNION
-SELECT 
-    i.id,
-    i.name,
-    'A' as type, 
-    i.return_datetime as returnTime,
-	i.price,
-	NULL as category_id,
-	NULL as plan_id,
-    i.created_at,
-    i.updated_at,
-	i.sharable_groups
-FROM community.inventory i
-) AS combined
-WHERE 
-(type = 'A' AND (returnTime IS NULL OR returnTime < CURRENT_TIMESTAMP))
-    OR type <> 'A'
-AND $1::UUID = ANY(sharable_groups)
-ORDER BY type, updated_at DESC;`
+	sqlStr := `SELECT 
+    id, 
+    name, 
+    type, 
+    returnTime, 
+    price, 
+	items,
+    created_at,
+    updated_at, 
+    sharable_groups 
+		FROM (
+			SELECT
+				c.id,
+				c.name,
+				'C' as type,
+				NULL::timestamp with time zone as returnTime,
+				0 as price,
+				array_agg(COALESCE(i.name, '')) AS items,
+				c.created_at,
+				c.updated_at,
+				c.sharable_groups
+			FROM community.category c
+			LEFT JOIN community.category_item ci ON c.id = ci.category_id
+			LEFT JOIN community.inventory i ON i.id = ci.item_id
+			GROUP BY c.id
+			UNION
+			SELECT
+				mp.id,
+				mp.name,
+				'M' as type,
+				NULL::timestamp with time zone as returnTime,
+				0 as price,
+				array_agg(COALESCE(i.name, '')) AS items,
+				mp.created_at,
+				mp.updated_at,
+				mp.sharable_groups
+			FROM community.maintenance_plan mp
+			LEFT JOIN community.maintenance_item mi ON mp.id = mi.maintenance_plan_id
+			LEFT JOIN community.inventory i ON i.id = mi.item_id
+			GROUP BY mp.id
+			UNION
+			SELECT 
+				i.id,
+				i.name,
+				'A' as type, 
+				i.return_datetime AS returnTime,
+				i.price,
+				ARRAY[]::TEXT[] AS items,
+				i.created_at,
+				i.updated_at,
+				i.sharable_groups
+			FROM community.inventory i
+			WHERE i.is_returnable = TRUE AND i.return_datetime IS NOT NULL AND i.return_datetime < CURRENT_TIMESTAMP
+		) AS combined
+		WHERE $1::UUID = ANY(sharable_groups)
+		ORDER BY type, updated_at DESC;`
 
 	rows, err := db.Query(sqlStr, userID)
 	if err != nil {
-		return nil, err
+		log.Printf("unable to retrieve asset summary details. error: %+v", err)
+		return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
 	}
 	defer rows.Close()
 
+	var response model.AssetsAndSummaryResponse
 	var data []model.AssetSummary
 
 	for rows.Next() {
 		var as model.AssetSummary
 		var returnDateTime pq.NullTime
-		var categoryID sql.NullString
-		var maintenancePlanID sql.NullString
+		var items pq.StringArray
 		var sharableGroups pq.StringArray
-		if err := rows.Scan(&as.ID, &as.Name, &as.Type, &returnDateTime, &as.Price, &categoryID, &maintenancePlanID, &as.CreatedAt, &as.UpdatedAt, &sharableGroups); err != nil {
-			return nil, err
+		if err := rows.Scan(&as.ID, &as.Name, &as.Type, &returnDateTime, &as.Price, &items, &as.CreatedAt, &as.UpdatedAt, &sharableGroups); err != nil {
+			log.Printf("unable to retrieve asset summary details. error: %+v", err)
+			return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
 		}
 
 		if returnDateTime.Valid {
 			as.ReturnTime = returnDateTime.Time
 		}
 
-		if categoryID.Valid {
-			as.CategoryID = categoryID.String
-		}
-
-		if maintenancePlanID.Valid {
-			as.PlanID = maintenancePlanID.String
-		}
+		as.Items = items
 
 		as.SharableGroups = sharableGroups
 		data = append(data, as)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, err
+		log.Printf("unable to retrieve asset summary details. error: %+v", err)
+		return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
 	}
 
-	return data, nil
+	sqlStr = `SELECT 
+	i.name, 
+	i.description, 
+	i.price, 
+	i.quantity, 
+	i.bought_at
+		FROM community.inventory i 
+	WHERE 
+		$1::UUID = ANY(sharable_groups) ORDER BY updated_at DESC;`
+
+	var inventories []model.Inventory
+
+	rows, err = db.Query(sqlStr, userID)
+	if err != nil {
+		log.Printf("unable to retrieve asset details in summary. error: %+v", err)
+		return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
+	}
+
+	for rows.Next() {
+		var i model.Inventory
+		if err := rows.Scan(&i.Name, &i.Description, &i.Price, &i.Quantity, &i.BoughtAt); err != nil {
+			log.Printf("unable to retrieve asset details in summary. error: %+v", err)
+			return model.AssetsAndSummaryResponse{AssetSummaryList: []model.AssetSummary{}, AssetList: []model.Inventory{}}, err
+		}
+		inventories = append(inventories, i)
+	}
+
+	response.AssetSummaryList = data
+	response.AssetList = inventories
+
+	return response, nil
 }

--- a/apilayer/db/Inventorydb.go
+++ b/apilayer/db/Inventorydb.go
@@ -329,8 +329,9 @@ func AddInventoryInBulk(user string, userID string, draftInventoryList model.Inv
 			created_by, 
 			created_at, 
 			updated_by, 
-			updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`
+			updated_at,
+			sharable_groups
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);`
 
 		_, err = tx.Exec(
 			sqlStr,
@@ -348,6 +349,7 @@ func AddInventoryInBulk(user string, userID string, draftInventoryList model.Inv
 			time.Now(),
 			parsedCreatedByUUID,
 			time.Now(),
+			pq.Array(v.SharableGroups),
 		)
 
 		if err != nil {

--- a/apilayer/handler/AssetSummaryHandler.go
+++ b/apilayer/handler/AssetSummaryHandler.go
@@ -8,17 +8,20 @@ import (
 	"github.com/mohit2530/communityCare/db"
 )
 
-// GetAssetSummary ...
-// swagger:route GET /api/v1/locations GetAssetSummary getAssetSummary
+// GetAssetsAndSummary ...
+// swagger:route GET /api/v1/locations GetAssetsAndSummary GetAssetsAndSummary
 //
-// # Retrieves the list of all assets and associated maintenance plans created by the select user
+// # Retrieves list of categories and its associated asset names, list of maintenance plans and its associated assets and
+// list of assets that are past due. For the asset list that is past due, if there is no returnable flag set, then it does not
+// return that values. Also returns an array of existing assets.
+// All results are created by the selected user and in order of type and date last updated at.
 //
 // Responses:
 // 200: []AssetSummary
 // 400: MessageResponse
 // 404: MessageResponse
 // 500: MessageResponse
-func GetAssetSummary(rw http.ResponseWriter, r *http.Request, user string) {
+func GetAssetsAndSummary(rw http.ResponseWriter, r *http.Request, user string) {
 
 	userID := r.URL.Query().Get("id")
 
@@ -28,7 +31,7 @@ func GetAssetSummary(rw http.ResponseWriter, r *http.Request, user string) {
 		json.NewEncoder(rw).Encode(nil)
 		return
 	}
-	resp, err := db.RetrieveAllAssetSummary(user, userID)
+	resp, err := db.RetrieveAssetsAndSummary(user, userID)
 	if err != nil {
 		log.Printf("Unable to retrieve asset summary. error: %v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/AssetSummaryHandler_test.go
+++ b/apilayer/handler/AssetSummaryHandler_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_GetAssetSummary(t *testing.T) {
+func Test_GetAssetsAndSummary(t *testing.T) {
 
 	// retrieve the selected profile
 	draftUserCredentials := model.UserCredentials{
@@ -31,7 +31,7 @@ func Test_GetAssetSummary(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/summary?id=%s", prevUser.ID.String()), nil)
 	w := httptest.NewRecorder()
-	GetAssetSummary(w, req, config.CTO_USER)
+	GetAssetsAndSummary(w, req, config.CTO_USER)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := io.ReadAll(res.Body)
@@ -39,29 +39,30 @@ func Test_GetAssetSummary(t *testing.T) {
 		t.Errorf("expected error to be nil got %v", err)
 	}
 
-	var assetSummary []model.AssetSummary
-	err = json.Unmarshal(data, &assetSummary)
+	var asResponse model.AssetsAndSummaryResponse
+	err = json.Unmarshal(data, &asResponse)
 	if err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
 
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Greater(t, len(data), 0)
-	assert.Greater(t, len(assetSummary), 0)
+	assert.Greater(t, len(asResponse.AssetList), 0)
+	assert.Greater(t, len(asResponse.AssetSummaryList), 0)
 }
 
-func Test_GetAssetSummary_IncorrectCategoryID(t *testing.T) {
+func Test_GetAssetsAndSummary_IncorrectCategoryID(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/categories?id=%s&limit=%d", "", 5), nil)
 	w := httptest.NewRecorder()
 	db.PreloadAllTestVariables()
-	GetAssetSummary(w, req, config.CTO_USER)
+	GetAssetsAndSummary(w, req, config.CTO_USER)
 	res := w.Result()
 
 	assert.Equal(t, 400, res.StatusCode)
 	assert.Equal(t, "400 Bad Request", res.Status)
 }
 
-func Test_GetAssetSummary_InvalidDBUser(t *testing.T) {
+func Test_GetAssetsAndSummary_InvalidDBUser(t *testing.T) {
 
 	// retrieve the selected profile
 	draftUserCredentials := model.UserCredentials{
@@ -79,7 +80,7 @@ func Test_GetAssetSummary_InvalidDBUser(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/categories?id=%s&limit=%d", prevUser.ID.String(), 5), nil)
 	w := httptest.NewRecorder()
 	db.PreloadAllTestVariables()
-	GetAssetSummary(w, req, config.CEO_USER)
+	GetAssetsAndSummary(w, req, config.CEO_USER)
 	res := w.Result()
 
 	assert.Equal(t, 400, res.StatusCode)

--- a/apilayer/handler/InventoriesHandler.go
+++ b/apilayer/handler/InventoriesHandler.go
@@ -134,19 +134,20 @@ func AddInventoryInBulk(rw http.ResponseWriter, r *http.Request, user string) {
 	for _, v := range inventoryMap {
 
 		draftInventory := model.Inventory{
-			Name:        v.Name,
-			Description: v.Description,
-			Price:       v.Price,
-			Status:      defaultHiddenStatus,
-			Barcode:     v.Barcode,
-			SKU:         v.SKU,
-			Quantity:    int(v.Quantity),
-			Location:    v.Location,
-			CreatedAt:   time.Now(),
-			CreatedBy:   userID,
-			UpdatedAt:   time.Now(),
-			UpdatedBy:   userID,
-			BoughtAt:    v.BoughtAt,
+			Name:           v.Name,
+			Description:    v.Description,
+			Price:          v.Price,
+			Status:         defaultHiddenStatus,
+			Barcode:        v.Barcode,
+			SKU:            v.SKU,
+			Quantity:       int(v.Quantity),
+			Location:       v.Location,
+			CreatedAt:      time.Now(),
+			CreatedBy:      userID,
+			UpdatedAt:      time.Now(),
+			UpdatedBy:      userID,
+			BoughtAt:       v.BoughtAt,
+			SharableGroups: []string{userID},
 		}
 		inventoryList = append(inventoryList, draftInventory)
 	}

--- a/apilayer/main.go
+++ b/apilayer/main.go
@@ -61,7 +61,7 @@ func main() {
 	router.Handle("/api/v1/status/list", CustomRequestHandler(handler.GetStatusList)).Methods(http.MethodGet)
 
 	// summary
-	router.Handle("/api/v1/summary", CustomRequestHandler(handler.GetAssetSummary)).Methods(http.MethodGet)
+	router.Handle("/api/v1/summary", CustomRequestHandler(handler.GetAssetsAndSummary)).Methods(http.MethodGet)
 
 	// categories
 	router.Handle("/api/v1/categories", CustomRequestHandler(handler.GetAllCategories)).Methods(http.MethodGet)

--- a/apilayer/model/AssetSummary.go
+++ b/apilayer/model/AssetSummary.go
@@ -12,9 +12,13 @@ type AssetSummary struct {
 	Type           string    `json:"type"`
 	ReturnTime     time.Time `json:"returntime"`
 	Price          float64   `json:"price"`
-	CategoryID     string    `json:"category_id"`
-	PlanID         string    `json:"plan_id"`
+	Items          []string  `json:"items"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 	SharableGroups []string  `json:"sharable_groups"`
+}
+
+type AssetsAndSummaryResponse struct {
+	AssetSummaryList []AssetSummary
+	AssetList        []Inventory
 }

--- a/apilayer/model/Inventory.go
+++ b/apilayer/model/Inventory.go
@@ -33,6 +33,7 @@ type Inventory struct {
 	UpdatedBy         string     `json:"updated_by"`
 	UpdaterName       string     `json:"updater_name"`
 	BoughtAt          string     `json:"bought_at"`
+	SharableGroups    []string   `json:"sharable_groups"`
 }
 
 // RawInventory ...

--- a/frontend/src/features/Layout/MenuActionBar.jsx
+++ b/frontend/src/features/Layout/MenuActionBar.jsx
@@ -26,12 +26,16 @@ import {
   Drawer,
   IconButton,
   Divider,
+  useMediaQuery,
+  Typography,
 } from '@mui/material';
 import { useTheme } from '@emotion/react';
 
 export default function MenuActionBar({ openDrawer, handleDrawerClose }) {
   const navigate = useNavigate();
   const theme = useTheme();
+  const smallerAndHigher = useMediaQuery(theme.breakpoints.up('sm'));
+
   const [openSettings, setOpenSettings] = useState(true);
   const [openPinnedResources, setOpenPinnedResources] = useState(true);
 
@@ -112,10 +116,31 @@ export default function MenuActionBar({ openDrawer, handleDrawerClose }) {
 
   return (
     <Stack display="flex">
-      <Drawer variant="temporary" open={openDrawer} onClose={handleDrawerClose} aria-modal="true">
-        <IconButton onClick={handleDrawerClose} sx={{ alignSelf: 'flex-end' }}>
+      <Drawer
+        variant="temporary"
+        open={openDrawer}
+        onClose={handleDrawerClose}
+        aria-modal="true"
+        PaperProps={
+          smallerAndHigher
+            ? {
+                sx: {
+                  width: 300,
+                },
+              }
+            : {
+                sx: {
+                  width: '100%',
+                },
+              }
+        }
+      >
+        <Stack sx={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: '1rem'}}>
+          <Typography variant='h5'>AssetAlert</Typography>
+        <IconButton onClick={handleDrawerClose}>
           {theme.direction === 'rtl' ? <ChevronRightRounded /> : <ChevronLeftRounded />}
         </IconButton>
+        </Stack>
         <Divider />
         <List sx={{ width: '100%' }} component="nav" aria-labelledby="nested-list-subheader">
           {parentMenuList.map((v) => (

--- a/frontend/src/features/common/utils.jsx
+++ b/frontend/src/features/common/utils.jsx
@@ -144,12 +144,17 @@ export const capitalizeFirstLetter = (string) => {
 /**
  * Function returns a string with prefix if prefix exists.
  * @param {string} prefixVal - the prefix value to append
- * @param {string} text - the text to append the prefix string onto
- * @returns string - result of combination of prefixValue and text
+ * @param {any} value - the value to append the prefix string onto
+ * @param {roundUpTo} int - rounds to certain number if the selected value is a number
+ * @returns any - result of combination of prefixValue and value
  */
-export const prefix = (prefixVal, text) => {
+export const prefix = (prefixVal, value, roundUpTo = 2) => {
   if (prefixVal != null) {
-    return `${prefixVal} ${text}`;
+    if (Number(value)) {
+      return `${prefixVal} ${Number(value).toFixed(roundUpTo)}`;
+    } else {
+      return `${prefixVal} ${value}`;
+    }
   }
-  return text;
+  return value;
 };


### PR DESCRIPTION
- updates asset summary details in landing page.
- displays items counts for categories, maintenance plan and displays count for overdue items.
- Update overview page to display items that require attention.
- Fix cost in overview page, and display correct counts of un-estimated items.
- Add summary and assets response in the summary api.
- Update utils to support better changes in prefix function and add ability to round down.
- add drawer width based on small screen size vs large
- update overview page with maintenance item details instead of categories


Screenshots / Visuals

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/8af3bbd6-3a10-4c25-85a4-9158e3990db1">
<img width="325" alt="image" src="https://github.com/user-attachments/assets/a8fc30db-1809-43f6-9739-45794c09a2c6">


closes https://github.com/earmuff-jam/mashed/issues/200