### PR TITLE
203 - Add ability to upload images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 docs
 node_modules
+local_uploads

--- a/apilayer/go.mod
+++ b/apilayer/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
-	github.com/gorilla/websocket v1.5.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.9.0
@@ -23,7 +23,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	golang.org/x/net v0.29.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/apilayer/go.sum
+++ b/apilayer/go.sum
@@ -13,8 +13,8 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -36,8 +36,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
-golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
-golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/apilayer/handler/FileServerHandler.go
+++ b/apilayer/handler/FileServerHandler.go
@@ -1,0 +1,226 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gorilla/mux"
+	"github.com/mohit2530/communityCare/service"
+)
+
+// GetAllFiles ...
+// swagger:route GET /filestat/list/{id} GetAllFiles getAllFiles
+//
+// # Retrieves the list of files associated with the selected user
+//
+// Parameters:
+//   - +name: id
+//     in: path
+//     description: The userID of the selected user
+//     type: string
+//     required: true
+//
+// Responses:
+// 200: MessageResponse
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func GetAllFiles(rw http.ResponseWriter, r *http.Request, user string) {
+
+	vars := mux.Vars(r)
+	userID := vars["id"]
+
+	if len(userID) <= 0 {
+		log.Printf("Unable to view files associated with the selected user.")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	directoryPath := filepath.Join("..", "local_uploads", userID)
+	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
+		log.Printf("Unable to view associated files. error: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	files, err := os.ReadDir(directoryPath)
+	if err != nil {
+		log.Printf("Unable to view associated files. error: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	fmt.Printf("%+v", files)
+	rw.WriteHeader(http.StatusOK)
+	json.NewEncoder(rw).Encode("200 OK")
+}
+
+// ServeFile ...
+// swagger:route GET /filestat/view/{id}/{filename} ServeFile serveFile
+//
+// # Retrieves the selected file associated with the user in binary form
+//
+// Parameters:
+//
+//   - +name: id
+//     in: path
+//     description: The userID of the selected user
+//     type: string
+//     required: true
+//   - +name: filename
+//     in: path
+//     description: The unique identifier for the selected file
+//     type: string
+//     required: true
+//
+// Responses:
+// 200: String
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func ServeFile(rw http.ResponseWriter, r *http.Request, user string) {
+
+	vars := mux.Vars(r)
+	userID := vars["id"]
+	if userID == "" {
+		log.Printf("Unable to retrieve selected file with empty id")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	filename := vars["filename"]
+	if filename == "" {
+		log.Printf("Unable to retrieve selected file without filename")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	filePath := filepath.Join("..", "local_uploads", userID, filename)
+	log.Printf("Serving file from path: %s", filePath)
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		rw.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	// Serve the file
+	rw.Header().Set("Content-Type", "image/jpeg")
+	http.ServeFile(rw, r, filePath)
+}
+
+// CreateFile ...
+// swagger:route POST /filestat/create/{id}/{type}/{itemID} CreateFile createFile
+//
+// # Adds the passed in image from the request body to the storage folder. The folder is created if it does not exists. If the folder exists, then the image is added to the file.
+//
+// Parameters:
+//
+//   - +name: id
+//     in: path
+//     description: The userID of the selected user
+//     type: string
+//     required: true
+//   - +name: type
+//     in: path
+//     description: The type of item the image must be associated with.
+//     type: rune
+//     enum: [C, A, M, P]
+//     required: true
+//   - +name: itemID
+//     in: path
+//     description: The itemID of the associated element the image is uploaded against
+//     type: string
+//     required: true
+//   - +name: File
+//     in: path
+//     description: The contents of the file limited to 2mb
+//     type: string
+//     format: binary
+//     required: true
+//
+// Responses:
+// 200: String
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func CreateFile(rw http.ResponseWriter, r *http.Request, user string) {
+
+	vars := mux.Vars(r)
+	userID := vars["id"]
+	itemID := vars["itemID"]
+	itemType := vars["type"]
+
+	if userID == "" {
+		log.Printf("Unable to created associated images with empty id")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	if itemID == "" {
+		log.Printf("Unable to created associated images with empty item id")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	runeElement := rune(itemType[0])
+	if !validItemType(runeElement) {
+		log.Printf("Unable to created associated images with incorrect item type")
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	// Limit size to 2MB
+	if err := r.ParseMultipartForm(2 << 20); err != nil {
+		log.Printf("Error parsing multipart form: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	file, _, err := r.FormFile("image")
+	if err != nil {
+		log.Printf("Unable to retrieve file. error: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+	defer file.Close()
+
+	fileID, err := service.UploadAndAssociateFile(file, runeElement, userID, itemID, user)
+	if err != nil {
+		log.Printf("unable to upload and associate file. error: %+v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	json.NewEncoder(rw).Encode(fileID)
+}
+
+// validItemType ...
+//
+// returns true if the item type is valid and is one of the rune elements 'C', 'A', 'M', 'P'
+func validItemType(itemType rune) bool {
+	itemTypes := []rune{'C', 'A', 'M', 'P'}
+
+	for _, v := range itemTypes {
+		if itemType == v {
+			return true
+		}
+	}
+	return false
+}

--- a/apilayer/model/Inventory.go
+++ b/apilayer/model/Inventory.go
@@ -9,32 +9,33 @@ import (
 //
 // Inventory is the selected row for each inventory
 type Inventory struct {
-	ID                string     `json:"id"`
-	Name              string     `json:"name"`
-	Description       string     `json:"description"`
-	Price             float64    `json:"price"`
-	Status            string     `json:"status"`
-	Barcode           string     `json:"barcode"`
-	SKU               string     `json:"sku"`
-	Quantity          int        `json:"quantity"`
-	Location          string     `json:"location"`
-	StorageLocationID string     `json:"storage_location_id"`
-	IsReturnable      bool       `json:"is_returnable"`
-	ReturnLocation    string     `json:"return_location"`
-	ReturnDateTime    *time.Time `json:"return_datetime,omitempty"`
-	ReturnNotes       string     `json:"return_notes,omitempty"`
-	MaxWeight         string     `json:"max_weight"`
-	MinWeight         string     `json:"min_weight"`
-	MaxHeight         string     `json:"max_height"`
-	MinHeight         string     `json:"min_height"`
-	CreatedAt         time.Time  `json:"created_at"`
-	CreatedBy         string     `json:"created_by"`
-	CreatorName       string     `json:"creator_name"`
-	UpdatedAt         time.Time  `json:"updated_at"`
-	UpdatedBy         string     `json:"updated_by"`
-	UpdaterName       string     `json:"updater_name"`
-	BoughtAt          string     `json:"bought_at"`
-	SharableGroups    []string   `json:"sharable_groups"`
+	ID                 string     `json:"id"`
+	Name               string     `json:"name"`
+	Description        string     `json:"description"`
+	Price              float64    `json:"price"`
+	Status             string     `json:"status"`
+	Barcode            string     `json:"barcode"`
+	SKU                string     `json:"sku"`
+	Quantity           int        `json:"quantity"`
+	Location           string     `json:"location"`
+	StorageLocationID  string     `json:"storage_location_id"`
+	IsReturnable       bool       `json:"is_returnable"`
+	ReturnLocation     string     `json:"return_location"`
+	ReturnDateTime     *time.Time `json:"return_datetime,omitempty"`
+	ReturnNotes        string     `json:"return_notes,omitempty"`
+	MaxWeight          string     `json:"max_weight"`
+	MinWeight          string     `json:"min_weight"`
+	MaxHeight          string     `json:"max_height"`
+	MinHeight          string     `json:"min_height"`
+	AssociatedImageURL string     `json:"associated_image_url"`
+	CreatedAt          time.Time  `json:"created_at"`
+	CreatedBy          string     `json:"created_by"`
+	CreatorName        string     `json:"creator_name"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+	UpdatedBy          string     `json:"updated_by"`
+	UpdaterName        string     `json:"updater_name"`
+	BoughtAt           string     `json:"bought_at"`
+	SharableGroups     []string   `json:"sharable_groups"`
 }
 
 // RawInventory ...

--- a/apilayer/service/FileUpload.go
+++ b/apilayer/service/FileUpload.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/mohit2530/communityCare/db"
+)
+
+const Upload_Directory = "local_uploads"
+
+// UploadAndAssociateFile ...
+//
+// upload image to the local system and associate it with the passed in id. the workflow can be associated with various tables we also pass in the type of association.
+func UploadAndAssociateFile(fileToProcess multipart.File, itemType rune, userID string, itemID string, user string) (string, error) {
+	uploadDir := filepath.Join("..", Upload_Directory, userID)
+	if err := os.MkdirAll(uploadDir, os.ModePerm); err != nil {
+		log.Printf("unable to create user directory for images. erorr: %+v", err)
+		return "", err
+	}
+
+	fileID := uuid.New().String()
+	dstFilePath := filepath.Join(uploadDir, fmt.Sprintf("%s.png", fileID))
+	dstFile, err := os.Create(dstFilePath)
+	if err != nil {
+		log.Printf("Error creating file: %+v", err)
+		return "", err
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, fileToProcess); err != nil {
+		log.Printf("Error saving file: %+v", err)
+		return "", err
+	}
+
+	err = associateImage(fileID, itemType, userID, itemID, user)
+	if err != nil {
+		log.Printf("unable to associate image with selected file. error: %+v", err)
+		_ = removeAssociatedImage(fileID, userID, user)
+		return "", err
+	}
+	return fileID, nil
+}
+
+// AssociateImage ...
+//
+// associates the selected image with the type of item that the image is targeted for. Eg, if the image is a type of asset, type would be 'A' and image id is the ID.
+func associateImage(imageID string, itemType rune, userID string, itemID string, user string) error {
+
+	switch itemType {
+	case 'C':
+		_, err := db.UpdateCategoryImage(user, userID, itemID, imageID)
+		if err != nil {
+			return err
+		}
+	case 'A':
+		_, err := db.UpdateAssetImage(user, userID, itemID, imageID)
+		if err != nil {
+			return err
+		}
+	case 'M':
+		_, err := db.UpdateMaintenancePlanImage(user, userID, itemID, imageID)
+		if err != nil {
+			return err
+		}
+	case 'P':
+		_, err := db.UpdateProfileImage(user, userID, imageID)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("unable to find selected item type")
+	}
+
+	return nil
+}
+
+// removeAssociatedImage ...
+//
+// removes the associated image from the selected folder where the image is stored.
+func removeAssociatedImage(imageID string, userID string, user string) error {
+
+	return nil
+}

--- a/apilayer/swagger.yaml
+++ b/apilayer/swagger.yaml
@@ -424,6 +424,16 @@ definitions:
             category_status:
                 type: string
                 x-go-name: CategoryStatus
+            created_at:
+                format: date-time
+                type: string
+                x-go-name: CreatedAt
+            created_by:
+                type: string
+                x-go-name: CreatedBy
+            creator:
+                type: string
+                x-go-name: Creator
             id:
                 type: string
                 x-go-name: ID
@@ -436,6 +446,22 @@ definitions:
             maintenance_plan_status:
                 type: string
                 x-go-name: MaintenancePlanStatus
+            sharable_groups:
+                items:
+                    format: uuid
+                    type: string
+                type: array
+                x-go-name: SharableGroups
+            updated_at:
+                format: date-time
+                type: string
+                x-go-name: UpdatedAt
+            updated_by:
+                type: string
+                x-go-name: UpdatedBy
+            updator:
+                type: string
+                x-go-name: Updator
         title: FavouriteItem ...
         type: object
         x-go-package: github.com/mohit2530/communityCare/model
@@ -2303,6 +2329,39 @@ paths:
             tags:
                 - GetUsername
     /api/v1/profile/{id}/fav:
+        delete:
+            operationId: removeFavItem
+            parameters:
+                - description: The userID of the selected user
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: The itemID to remove from the db
+                  in: query
+                  name: itemID
+                  required: true
+                  type: string
+            responses:
+                "200":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+                "400":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+                "404":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+                "500":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+            summary: Deletes the item that is marked as favourite by the user
+            tags:
+                - RemoveFavItem
         get:
             operationId: getFavouriteItems
             parameters:
@@ -2311,6 +2370,11 @@ paths:
                   name: id
                   required: true
                   type: string
+                - description: The limit of items to return. If not passed in defaults to 1000
+                  format: int32
+                  in: query
+                  name: limit
+                  type: integer
             responses:
                 "200":
                     description: FavouriteItem
@@ -2333,6 +2397,44 @@ paths:
             summary: '# Retrieves the items marked as favourite by the selected user.'
             tags:
                 - GetFavouriteItems
+        post:
+            operationId: saveFavItem
+            parameters:
+                - description: The userID of the selected user
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: The object that is marked favourite by the user
+                  in: body
+                  name: FavouriteItem
+                  required: true
+                  schema:
+                    $ref: '#/definitions/FavouriteItem'
+                    description: The object that is marked favourite by the user
+                    type: object
+            responses:
+                "200":
+                    description: FavouriteItem
+                    schema:
+                        items:
+                            $ref: '#/definitions/FavouriteItem'
+                        type: array
+                "400":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+                "404":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+                "500":
+                    description: MessageResponse
+                    schema:
+                        $ref: '#/definitions/MessageResponse'
+            summary: Creates a new favourite item for the selected user
+            tags:
+                - SaveFavItem
     /api/v1/profile/{id}/inventories:
         get:
             operationId: getAllInventories

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -13,5 +13,6 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./local_uploads:/app/uploads # doing this, we are sharing the volume between container and local dev instance
 volumes:
   pg_data:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -30,6 +30,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./local_uploads:/app/uploads
 
   apilayer:
     build:
@@ -51,6 +52,7 @@ services:
       DATABASE_DOCKER_CONTAINER_IP_ADDRESS: backend
     volumes:
       - api_layer:/usr/src/
+      - ./local_uploads:/app/uploads
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./local_uploads:/app/uploads
   apilayer:
     build:
       context: ./apilayer
@@ -27,6 +28,7 @@ services:
       DATABASE_DOCKER_CONTAINER_IP_ADDRESS: backend
     volumes:
       - api_layer:/usr/src/
+      - ./local_uploads:/app/uploads
     depends_on:
       - backend
   frontend:

--- a/frontend/src/features/Home/Collection/LearnMore.jsx
+++ b/frontend/src/features/Home/Collection/LearnMore.jsx
@@ -15,7 +15,7 @@ const LearnMore = ({ items = [] }) => {
             <CardMedia
               component="img"
               sx={{ height: '20vh' }} // 16:9 aspect ratio
-              image={item.imageSrc}
+              image={item.imageSrc || '/blank_canvas.png'}
               alt={item.imageAlt}
             />
             <CardContent>

--- a/frontend/src/features/InventoryList/InventoryListDetails.jsx
+++ b/frontend/src/features/InventoryList/InventoryListDetails.jsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Autocomplete, Dialog, DialogTitle, IconButton, Slide, Stack, TextField } from '@mui/material';
-import {
-  CheckRounded,
-  CloseRounded,
-  EditRounded,
-  GridViewRounded,
-  ViewListRounded,
-} from '@mui/icons-material';
+import { CheckRounded, CloseRounded, EditRounded, GridViewRounded, ViewListRounded } from '@mui/icons-material';
 import HeaderWithButton from '../common/HeaderWithButton';
 import SimpleModal from '../common/SimpleModal';
 import { ConfirmationBoxModal, generateTitleColor } from '../common/utils';
@@ -214,7 +208,12 @@ const InventoryListDetails = ({ hideActionMenu = false }) => {
         renderInput={(params) => <TextField variant="standard" {...params} label="Search ..." />}
       />
       {gridMode ? (
-        <GridComponent isLoading={loading} data={options} rowSelected={rowSelected} />
+        <GridComponent
+          isLoading={loading}
+          data={options}
+          rowSelected={rowSelected}
+          handleRowSelection={handleRowSelection}
+        />
       ) : (
         <TableComponent
           isLoading={loading}

--- a/frontend/src/features/InventoryList/inventorySlice.js
+++ b/frontend/src/features/InventoryList/inventorySlice.js
@@ -126,15 +126,40 @@ const inventorySlice = createSlice({
       state.loading = true;
       state.error = '';
     },
-    getStorageLocationsSuccess: (state, action) => {
+    getStorageLocationsSuccess: (state) => {
       state.loading = false;
       state.error = '';
-      state.storageLocations = action.payload;
     },
     getStorageLocationsFailure: (state) => {
       state.loading = false;
       state.error = '';
-      state.storageLocations = [];
+    },
+    retrieveSelectedImage: (state) => {
+      state.error = '';
+    },
+    retrieveSelectedImageSuccess: (state, action) => {
+      const updatedItem = { ...action.payload };
+      const assetID = updatedItem.assetID;
+      state.inventories = state.inventories.map((item) =>
+        item.id === assetID ? { ...item, selectedImage: updatedItem.imageData } : item
+      );
+      state.loading = false;
+      state.error = '';
+    },
+    retrieveSelectedImageFailure: (state) => {
+      state.error = '';
+    },
+    createInventoryImage: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    createInventoryImageSuccess: (state) => {
+      state.loading = false;
+      state.error = '';
+    },
+    createInventoryImageFailure: (state) => {
+      state.loading = false;
+      state.error = '';
     },
   },
 });

--- a/frontend/src/features/common/ImagePicker/ImagePicker.jsx
+++ b/frontend/src/features/common/ImagePicker/ImagePicker.jsx
@@ -1,0 +1,48 @@
+import { InfoRounded } from '@mui/icons-material';
+import { Button, Stack, Tooltip, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { inventoryActions } from '../../InventoryList/inventorySlice';
+import { enqueueSnackbar } from 'notistack';
+
+export default function ImagePicker({ selectedData = {}, handleClose }) {
+  const dispatch = useDispatch();
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  const handleFileUpload = (event) => {
+    const file = event.target.files[0];
+    const sizeInMB = (file.size / (1024 * 1024)).toFixed(2);
+    const imageType = file.type.includes('image');
+    if (sizeInMB > 2.0 || !imageType) {
+      enqueueSnackbar('Image is not valid or exceeds 2mb size limit.', {
+        variant: 'error',
+      });
+      return;
+    } else {
+      setSelectedImage(file);
+    }
+  };
+
+  const handleUpload = () => {
+    const formData = new FormData();
+    formData.append('image', selectedImage);
+    dispatch(inventoryActions.createInventoryImage({ assetID: selectedData.id, imageData: formData }));
+    handleClose();
+  };
+
+  return (
+    <Stack spacing="1rem">
+      <Stack direction="row" spacing="0.2rem">
+        <Typography variant="caption">Select an image to associate with {selectedData.name || ''}</Typography>
+        <Tooltip title="Images should be less than 2mb and be of either png, jpg, jpeg or svg format">
+          <InfoRounded sx={{ color: 'grey' }} fontSize="small" />
+        </Tooltip>
+      </Stack>
+
+      <input type="file" onChange={handleFileUpload} />
+      <Button disabled={!selectedImage} onClick={handleUpload}>
+        Upload
+      </Button>
+    </Stack>
+  );
+}

--- a/frontend/src/util/Instances.js
+++ b/frontend/src/util/Instances.js
@@ -20,14 +20,14 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
-
 // catch any unauthorized request
 instance.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (UNAUTHORIZED_INSTANCES.includes(error.response.status)) {
+    if (UNAUTHORIZED_INSTANCES.includes(error?.response?.status)) {
       localStorage.removeItem('userID');
       window.history.replaceState({}, '');
+      window.location = '/';
     }
   }
 );

--- a/main.sh
+++ b/main.sh
@@ -25,6 +25,12 @@ loadEnv() {
     ./setup/_loadEnvVariables.sh
 }
 
+adjustPermissions() {
+    # set permissions for new folder
+    echo "resetting permissions on local_uploads folder."
+    chmod +x setup/_adjust_perm_local_uploads.sh
+    ./setup/_adjust_perm_local_uploads.sh
+}
 
 loadDb() {
     echo "loadDb flag provided. building psql docker image and running migrations."
@@ -41,6 +47,9 @@ loadDevEnv() {
 
     sleep +2
     loadMigration
+
+    sleep +2
+    adjustPermissions
 
     sleep +2
     loadData
@@ -60,6 +69,9 @@ loadUnitTest() {
 
     sleep +2
     loadMigration
+
+    sleep +2
+    adjustPermissions
 
     sleep +2
     loadData

--- a/server/migrations/0022_update_table_support_images.up.sql
+++ b/server/migrations/0022_update_table_support_images.up.sql
@@ -1,0 +1,17 @@
+
+-- File: 0022_update_table_support_images.up.sql
+-- Description: Update profiles, inventories, categories and maintenance plan tables to support images
+
+SET search_path TO community, public;
+
+ALTER TABLE community.profiles
+ADD COLUMN associated_image_url TEXT;
+
+ALTER TABLE community.inventory
+ADD COLUMN associated_image_url TEXT;
+
+ALTER TABLE community.category
+ADD COLUMN associated_image_url TEXT;
+
+ALTER TABLE community.maintenance_plan
+ADD COLUMN associated_image_url TEXT;

--- a/setup/_adjust_perm_local_uploads.sh
+++ b/setup/_adjust_perm_local_uploads.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DIRECTORY=./local_uploads
+
+USER_UID=$(id -u)
+USER_GID=$(id -g)
+
+sudo chown -R ${USER_UID}:${USER_GID} $DIRECTORY
+echo "Changed ownership of $DIRECTORY to $USER_UID:$USER_GID"

--- a/setup/docker_guide.md
+++ b/setup/docker_guide.md
@@ -56,4 +56,5 @@ psql -h docker_container_ip -p 5432 -U postgres -d <db_name>
 
 ## Troubleshooting with docker
 
-1. `enter a selected container` - `docker exec -it <service_name> bash`
+1. Enter a selected container with cmd - `docker exec -it <service_name> bash`
+2. Pry inside a running container with shell - `docker exec -it <container_id_or_name> /bin/bash`


### PR DESCRIPTION
Update docker compose file

- updated docker compose file to support housing of local_images folder in the application. this will allow us to keep uploaded images separate that the application itself.

Added filePath directory in main api.go layer

- the go service will serve up the file server api. this will support loading and uploading images to and from the local_uploads folder.

Added support to read images from volume

- added go api to retrieve files from local_uploads folder
- added local_uploads folder to gitignore so that we don't mistakely upload images
- added two api endpoints to return images in the filesystem. this part will require more cleanup. currently files are stored within local_uploads/userID. if the user id changes we also need to be able to update that, and we also need to be able to know / limit the size of the uploads. Furthermore, when the container is closed, we need to make sure images are removed so the space is saved and this also needs to work in other docker env files. currently support is built for local dev setup. later on, we will need the same support in prod env.

Add permission script and add new apis

- added new permission script to allow read / write access to local_uploads folder. since docker uses root as the main user, we need to add the proper permissions so it can upload data into the local_uploads folder.

Update existing create api for file system

- altered api to create the new file inside the local_uploads folder.

Build frontend for image picker

- added ability to upload files and view them from the backend
- added saga and redux actions for image
- added support with formData for images.
- updated api layer to support association handler for images
- updated integration for inventories

Create sql file to support image url

- added new sql script to support images upload
- added image and display in inventories

Address displaying images for inventories

- updated api call in GridComponent to support only if there is an associated item url.
- added takeEvery for redux action so that we don't leave behind the selected images for certain
components.
- added 2mb limit to image upload
- added check to ensure the file is an image type.
- added snackbar to failure messages.

Tech debt

- tech debt cleanup
- added redirect to home after error has occurred
- added new swagger changes


# Screenshots / Visuals

<img width="977" alt="image" src="https://github.com/user-attachments/assets/44defee2-ec01-4232-a673-3c2ade176b03">
<img width="806" alt="image" src="https://github.com/user-attachments/assets/a3f4dd57-2214-4a26-ae91-c4513a91886c">
<img width="875" alt="image" src="https://github.com/user-attachments/assets/301b4b19-0921-4438-9748-e40814866df6">

Closes #203 